### PR TITLE
Adopt nullability annotations for cleaner Swift headers

### DIFF
--- a/PINCache/Nullability.h
+++ b/PINCache/Nullability.h
@@ -1,9 +1,6 @@
-//
-//  nullability.h
-//  PINCache
-//
-//  Created by CHEN Xian’an on 3/19/15.
-//
+//  PINCache is a modified version of TMCache
+//  Modifications by Garrett Moon
+//  Copyright (c) 2015 Pinterest. All rights reserved.
 
 #ifndef PINCache_nullability_h
 #define PINCache_nullability_h

--- a/PINCache/Nullability.h
+++ b/PINCache/Nullability.h
@@ -3,7 +3,6 @@
 //  PINCache
 //
 //  Created by CHEN Xian’an on 3/19/15.
-//  Copyright (c) 2015 Tumblr. All rights reserved.
 //
 
 #ifndef PINCache_nullability_h

--- a/PINCache/PINCache.h
+++ b/PINCache/PINCache.h
@@ -7,6 +7,8 @@
 #import "PINDiskCache.h"
 #import "PINMemoryCache.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class PINCache;
 
 /**
@@ -19,7 +21,7 @@ typedef void (^PINCacheBlock)(PINCache *cache);
  A callback block which provides the cache, key and object as arguments
  */
 
-typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id object);
+typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullable object);
 
 /**
  `PINCache` is a thread safe key/value store designed for persisting temporary objects that are expensive to
@@ -195,3 +197,5 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id object);
 - (void)removeAllObjects;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/PINCache/PINCache.h
+++ b/PINCache/PINCache.h
@@ -121,7 +121,7 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  @param key A key to associate with the object. This string will be copied.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(PINCacheObjectBlock)block;
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed
@@ -130,7 +130,7 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  @param key The key associated with the object to be removed.
  @param block A block to be executed concurrently after the object has been removed, or nil.
  */
-- (void)removeObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block;
+- (void)removeObjectForKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes all objects from the cache that have not been used since the specified date. This method returns immediately and
@@ -139,7 +139,7 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  @param date Objects that haven't been accessed since this date are removed from the cache.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)trimToDate:(NSDate *)date block:(PINCacheBlock)block;
+- (void)trimToDate:(NSDate *)date block:(nullable PINCacheBlock)block;
 
 /**
  Removes all objects from the cache.This method returns immediately and executes the passed block after the
@@ -147,7 +147,7 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  
  @param block A block to be executed concurrently after the cache has been cleared, or nil.
  */
-- (void)removeAllObjects:(PINCacheBlock)block;
+- (void)removeAllObjects:(nullable PINCacheBlock)block;
 
 #pragma mark -
 /// @name Synchronous Methods

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -3,7 +3,7 @@
 //  Copyright (c) 2015 Pinterest. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import "nullability.h"
+#import "Nullability.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -178,7 +178,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  
  @param block A block to be executed when a lock is available.
  */
-- (void)lockFileAccessWhileExecutingBlock:(PINDiskCacheBlock)block;
+- (void)lockFileAccessWhileExecutingBlock:(nullable PINDiskCacheBlock)block;
 
 /**
  Retrieves the object for the specified key. This method returns immediately and executes the passed
@@ -189,7 +189,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param key The key associated with the requested object.
  @param block A block to be executed serially when the object is available.
  */
-- (void)objectForKey:(NSString *)key block:(PINDiskCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Retrieves the fileURL for the specified key without actually reading the data from disk. This method
@@ -211,7 +211,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param key A key to associate with the object. This string will be copied.
  @param block A block to be executed serially after the object has been stored, or nil.
  */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(PINDiskCacheObjectBlock)block;
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed block
@@ -220,7 +220,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param key The key associated with the object to be removed.
  @param block A block to be executed serially after the object has been removed, or nil.
  */
-- (void)removeObjectForKey:(NSString *)key block:(PINDiskCacheObjectBlock)block;
+- (void)removeObjectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Removes all objects from the cache that have not been used since the specified date.
@@ -229,7 +229,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param date Objects that haven't been accessed since this date are removed from the cache.
  @param block A block to be executed serially after the cache has been trimmed, or nil.
  */
-- (void)trimToDate:(NSDate *)date block:(PINDiskCacheBlock)block;
+- (void)trimToDate:(NSDate *)date block:(nullable PINDiskCacheBlock)block;
 
 /**
  Removes objects from the cache, largest first, until the cache is equal to or smaller than the specified byteCount.
@@ -238,7 +238,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param byteCount The cache will be trimmed equal to or smaller than this size.
  @param block A block to be executed serially after the cache has been trimmed, or nil.
  */
-- (void)trimToSize:(NSUInteger)byteCount block:(PINDiskCacheBlock)block;
+- (void)trimToSize:(NSUInteger)byteCount block:(nullable PINDiskCacheBlock)block;
 
 /**
  Removes objects from the cache, ordered by date (least recently used first), until the cache is equal to or smaller
@@ -256,7 +256,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  
  @param block A block to be executed serially after the cache has been cleared, or nil.
  */
-- (void)removeAllObjects:(PINDiskCacheBlock)block;
+- (void)removeAllObjects:(nullable PINDiskCacheBlock)block;
 
 /**
  Loops through all objects in the cache (reads and writes are suspended during the enumeration). Data is not actually
@@ -266,7 +266,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param block A block to be executed for every object in the cache.
  @param completionBlock An optional block to be executed after the enumeration is complete.
  */
-- (void)enumerateObjectsWithBlock:(PINDiskCacheObjectBlock)block completionBlock:(PINDiskCacheBlock)completionBlock;
+- (void)enumerateObjectsWithBlock:(PINDiskCacheObjectBlock)block completionBlock:(nullable PINDiskCacheBlock)completionBlock;
 
 #pragma mark -
 /// @name Synchronous Methods
@@ -279,7 +279,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  
  @param block A block to be executed when a lock is available.
  */
-- (void)synchronouslyLockFileAccessWhileExecutingBlock:(PINDiskCacheBlock)block;
+- (void)synchronouslyLockFileAccessWhileExecutingBlock:(nullable PINDiskCacheBlock)block;
 
 /**
  Retrieves the object for the specified key. This method blocks the calling thread until the
@@ -300,7 +300,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param key The key associated with the object.
  @result The file URL for the specified key.
  */
-- (NSURL *)fileURLForKey:(NSString *)key;
+- (NSURL *)fileURLForKey:(nullable NSString *)key;
 
 /**
  Stores an object in the cache for the specified key. This method blocks the calling thread until
@@ -325,7 +325,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  This method blocks the calling thread until the cache has been trimmed.
  @param date Objects that haven't been accessed since this date are removed from the cache.
  */
-- (void)trimToDate:(NSDate *)date;
+- (void)trimToDate:(nullable NSDate *)date;
 
 /**
  Removes objects from the cache, largest first, until the cache is equal to or smaller than the
@@ -355,7 +355,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @warning Do not call this method within the event blocks (<didRemoveObjectBlock>, etc.)
  Instead use the asynchronous version, <enumerateObjectsWithBlock:completionBlock:>.
  */
-- (void)enumerateObjectsWithBlock:(PINDiskCacheObjectBlock)block;
+- (void)enumerateObjectsWithBlock:(nullable PINDiskCacheObjectBlock)block;
 
 @end
 

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -3,6 +3,9 @@
 //  Copyright (c) 2015 Pinterest. All rights reserved.
 
 #import <Foundation/Foundation.h>
+#import "nullability.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @class PINDiskCache;
 
@@ -16,7 +19,7 @@ typedef void (^PINDiskCacheBlock)(PINDiskCache *cache);
  A callback block which provides the cache, key and object as arguments
  */
 
-typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding> object, NSURL *fileURL);
+typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding>  __nullable object, NSURL *fileURL);
 
 /**
  `PINDiskCache` is a thread safe key/value store backed by the file system. It accepts any object conforming
@@ -42,6 +45,8 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  */
 
 @interface PINDiskCache : NSObject
+
+
 
 #pragma mark -
 /// @name Core
@@ -98,34 +103,34 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
 /**
  A block to be executed just before an object is added to the cache. The queue waits during execution.
  */
-@property (copy) PINDiskCacheObjectBlock willAddObjectBlock;
+@property (copy) PINDiskCacheObjectBlock __nullable willAddObjectBlock;
 
 /**
  A block to be executed just before an object is removed from the cache. The queue waits during execution.
  */
-@property (copy) PINDiskCacheObjectBlock willRemoveObjectBlock;
+@property (copy) PINDiskCacheObjectBlock __nullable willRemoveObjectBlock;
 
 /**
  A block to be executed just before all objects are removed from the cache as a result of <removeAllObjects:>.
  The queue waits during execution.
  */
-@property (copy) PINDiskCacheBlock willRemoveAllObjectsBlock;
+@property (copy) PINDiskCacheBlock __nullable willRemoveAllObjectsBlock;
 
 /**
  A block to be executed just after an object is added to the cache. The queue waits during execution.
  */
-@property (copy) PINDiskCacheObjectBlock didAddObjectBlock;
+@property (copy) PINDiskCacheObjectBlock __nullable didAddObjectBlock;
 
 /**
  A block to be executed just after an object is removed from the cache. The queue waits during execution.
  */
-@property (copy) PINDiskCacheObjectBlock didRemoveObjectBlock;
+@property (copy) PINDiskCacheObjectBlock __nullable didRemoveObjectBlock;
 
 /**
  A block to be executed just after all objects are removed from the cache as a result of <removeAllObjects:>.
  The queue waits during execution.
  */
-@property (copy) PINDiskCacheBlock didRemoveAllObjectsBlock;
+@property (copy) PINDiskCacheBlock __nullable didRemoveAllObjectsBlock;
 
 #pragma mark -
 /// @name Initialization
@@ -196,7 +201,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param key The key associated with the requested object.
  @param block A block to be executed serially when the file URL is available.
  */
-- (void)fileURLForKey:(NSString *)key block:(PINDiskCacheObjectBlock)block;
+- (void)fileURLForKey:(nullable NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
@@ -243,7 +248,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param byteCount The cache will be trimmed equal to or smaller than this size.
  @param block A block to be executed serially after the cache has been trimmed, or nil.
  */
-- (void)trimToSizeByDate:(NSUInteger)byteCount block:(PINDiskCacheBlock)block;
+- (void)trimToSizeByDate:(NSUInteger)byteCount block:(nullable PINDiskCacheBlock)block;
 
 /**
  Removes all objects from the cache. This method returns immediately and executes the passed block as soon as the
@@ -353,3 +358,5 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
 - (void)enumerateObjectsWithBlock:(PINDiskCacheObjectBlock)block;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/PINCache/PINMemoryCache.h
+++ b/PINCache/PINMemoryCache.h
@@ -3,7 +3,7 @@
 //  Copyright (c) 2015 Pinterest. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import "nullability.h"
+#import "Nullability.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/PINCache/PINMemoryCache.h
+++ b/PINCache/PINMemoryCache.h
@@ -154,7 +154,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  @param key The key associated with the requested object.
  @param block A block to be executed concurrently when the object is available.
  */
-- (void)objectForKey:(NSString *)key block:(PINMemoryCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
@@ -177,7 +177,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  @param cost An amount to add to the <totalCost>.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINMemoryCacheObjectBlock)block;
+- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINMemoryCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed
@@ -186,7 +186,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  @param key The key associated with the object to be removed.
  @param block A block to be executed concurrently after the object has been removed, or nil.
  */
-- (void)removeObjectForKey:(NSString *)key block:(PINMemoryCacheObjectBlock)block;
+- (void)removeObjectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block;
 
 /**
  Removes all objects from the cache that have not been used since the specified date.
@@ -196,7 +196,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  @param date Objects that haven't been accessed since this date are removed from the cache.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)trimToDate:(NSDate *)date block:(PINMemoryCacheBlock)block;
+- (void)trimToDate:(NSDate *)date block:(nullable PINMemoryCacheBlock)block;
 
 /**
  Removes objects from the cache, costliest objects first, until the <totalCost> is below the specified
@@ -206,7 +206,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  @param cost The total accumulation allowed to remain after the cache has been trimmed.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)trimToCost:(NSUInteger)cost block:(PINMemoryCacheBlock)block;
+- (void)trimToCost:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block;
 
 /**
  Removes objects from the cache, ordered by date (least recently used first), until the <totalCost> is below
@@ -216,7 +216,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  @param cost The total accumulation allowed to remain after the cache has been trimmed.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)trimToCostByDate:(NSUInteger)cost block:(PINMemoryCacheBlock)block;
+- (void)trimToCostByDate:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block;
 
 /**
  Removes all objects from the cache. This method returns immediately and executes the passed block after
@@ -233,7 +233,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  @param block A block to be executed for every object in the cache.
  @param completionBlock An optional block to be executed concurrently when the enumeration is complete.
  */
-- (void)enumerateObjectsWithBlock:(PINMemoryCacheObjectBlock)block completionBlock:(PINMemoryCacheBlock)completionBlock;
+- (void)enumerateObjectsWithBlock:(PINMemoryCacheObjectBlock)block completionBlock:(nullable PINMemoryCacheBlock)completionBlock;
 
 #pragma mark -
 /// @name Synchronous Methods
@@ -246,7 +246,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  @param key The key associated with the object.
  @result The object for the specified key.
  */
-- (id)objectForKey:(NSString *)key;
+- (id)objectForKey:(nullable NSString *)key;
 
 /**
  Stores an object in the cache for the specified key. This method blocks the calling thread until the object
@@ -267,7 +267,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  @param key A key to associate with the object. This string will be copied.
  @param cost An amount to add to the <totalCost>.
  */
-- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost;
+- (void)setObject:(nullable id)object forKey:(nullable NSString *)key withCost:(NSUInteger)cost;
 
 /**
  Removes the object for the specified key. This method blocks the calling thread until the object
@@ -275,7 +275,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  
  @param key The key associated with the object to be removed.
  */
-- (void)removeObjectForKey:(NSString *)key;
+- (void)removeObjectForKey:(nullable NSString *)key;
 
 /**
  Removes all objects from the cache that have not been used since the specified date.
@@ -283,7 +283,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  
  @param date Objects that haven't been accessed since this date are removed from the cache.
  */
-- (void)trimToDate:(NSDate *)date;
+- (void)trimToDate:(nullable NSDate *)date;
 
 /**
  Removes objects from the cache, costliest objects first, until the <totalCost> is below the specified
@@ -317,7 +317,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  Instead use the asynchronous version, <enumerateObjectsWithBlock:completionBlock:>.
  
  */
-- (void)enumerateObjectsWithBlock:(PINMemoryCacheObjectBlock)block;
+- (void)enumerateObjectsWithBlock:(nullable PINMemoryCacheObjectBlock)block;
 
 @end
 

--- a/PINCache/PINMemoryCache.h
+++ b/PINCache/PINMemoryCache.h
@@ -3,6 +3,9 @@
 //  Copyright (c) 2015 Pinterest. All rights reserved.
 
 #import <Foundation/Foundation.h>
+#import "nullability.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @class PINMemoryCache;
 
@@ -15,7 +18,7 @@ typedef void (^PINMemoryCacheBlock)(PINMemoryCache *cache);
 /**
  A callback block which provides the cache, key and object as arguments
  */
-typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, id object);
+typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, id __nullable object);
 
 /**
  `PINMemoryCache` is a fast, thread safe key/value store similar to `NSCache`. On iOS it will clear itself
@@ -82,54 +85,54 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheObjectBlock willAddObjectBlock;
+@property (copy) PINMemoryCacheObjectBlock __nullable willAddObjectBlock;
 
 /**
  A block to be executed just before an object is removed from the cache. This block will be excuted
  within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheObjectBlock willRemoveObjectBlock;
+@property (copy) PINMemoryCacheObjectBlock __nullable willRemoveObjectBlock;
 
 /**
  A block to be executed just before all objects are removed from the cache as a result of <removeAllObjects:>.
  This block will be excuted within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheBlock willRemoveAllObjectsBlock;
+@property (copy) PINMemoryCacheBlock __nullable willRemoveAllObjectsBlock;
 
 /**
  A block to be executed just after an object is added to the cache. This block will be excuted within
  a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheObjectBlock didAddObjectBlock;
+@property (copy) PINMemoryCacheObjectBlock __nullable didAddObjectBlock;
 
 /**
  A block to be executed just after an object is removed from the cache. This block will be excuted
  within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheObjectBlock didRemoveObjectBlock;
+@property (copy) PINMemoryCacheObjectBlock __nullable didRemoveObjectBlock;
 
 /**
  A block to be executed just after all objects are removed from the cache as a result of <removeAllObjects:>.
  This block will be excuted within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheBlock didRemoveAllObjectsBlock;
+@property (copy) PINMemoryCacheBlock __nullable didRemoveAllObjectsBlock;
 
 /**
  A block to be executed upon receiving a memory warning (iOS only) potentially in parallel with other blocks on the <queue>.
  This block will be executed regardless of the value of <removeAllObjectsOnMemoryWarning>. Defaults to `nil`.
  */
-@property (copy) PINMemoryCacheBlock didReceiveMemoryWarningBlock;
+@property (copy) PINMemoryCacheBlock __nullable didReceiveMemoryWarningBlock;
 
 /**
  A block to be executed when the app enters the background (iOS only) potentially in parallel with other blocks on the <concurrentQueue>.
  This block will be executed regardless of the value of <removeAllObjectsOnEnteringBackground>. Defaults to `nil`.
  */
-@property (copy) PINMemoryCacheBlock didEnterBackgroundBlock;
+@property (copy) PINMemoryCacheBlock __nullable didEnterBackgroundBlock;
 
 #pragma mark -
 /// @name Shared Cache
@@ -161,7 +164,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  @param key A key to associate with the object. This string will be copied.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)setObject:(id)object forKey:(NSString *)key block:(PINMemoryCacheObjectBlock)block;
+- (void)setObject:(id)object forKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key and the specified cost. If the cost causes the total
@@ -221,7 +224,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  
  @param block A block to be executed concurrently after the cache has been cleared, or nil.
  */
-- (void)removeAllObjects:(PINMemoryCacheBlock)block;
+- (void)removeAllObjects:(nullable PINMemoryCacheBlock)block;
 
 /**
  Loops through all objects in the cache with reads and writes suspended. Calling serial methods which
@@ -317,3 +320,5 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
 - (void)enumerateObjectsWithBlock:(PINMemoryCacheObjectBlock)block;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/PINCache/nullability.h
+++ b/PINCache/nullability.h
@@ -1,0 +1,24 @@
+//
+//  nullability.h
+//  PINCache
+//
+//  Created by CHEN Xian’an on 3/19/15.
+//  Copyright (c) 2015 Tumblr. All rights reserved.
+//
+
+#ifndef PINCache_nullability_h
+#define PINCache_nullability_h
+
+#if !__has_feature(nullability)
+#define NS_ASSUME_NONNULL_BEGIN
+#define NS_ASSUME_NONNULL_END
+#define nullable
+#define nonnull
+#define null_unspecified
+#define null_resettable
+#define __nullable
+#define __nonnull
+#define __null_unspecified
+#endif
+
+#endif

--- a/tests/PINCache.xcodeproj/project.pbxproj
+++ b/tests/PINCache.xcodeproj/project.pbxproj
@@ -36,8 +36,8 @@
 		D0E5D844171DF0AF0041E777 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E5D83F171DF0AF0041E777 /* PINMemoryCache.m */; };
 		D0E5D845171DF0AF0041E777 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E5D83F171DF0AF0041E777 /* PINMemoryCache.m */; };
 		D0E5D848171DF0FA0041E777 /* PINExampleView.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E5D847171DF0FA0041E777 /* PINExampleView.m */; };
-		E0BE3BFE1ABA6BD000B516E5 /* nullability.h in Headers */ = {isa = PBXBuildFile; fileRef = E0BE3BFD1ABA6B6900B516E5 /* nullability.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E0BE3BFF1ABA6BD700B516E5 /* nullability.h in Headers */ = {isa = PBXBuildFile; fileRef = E0BE3BFD1ABA6B6900B516E5 /* nullability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E0BE3BFE1ABA6BD000B516E5 /* Nullability.h in Headers */ = {isa = PBXBuildFile; fileRef = E0BE3BFD1ABA6B6900B516E5 /* Nullability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E0BE3BFF1ABA6BD700B516E5 /* Nullability.h in Headers */ = {isa = PBXBuildFile; fileRef = E0BE3BFD1ABA6B6900B516E5 /* Nullability.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,7 +91,7 @@
 		D0E5D83F171DF0AF0041E777 /* PINMemoryCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PINMemoryCache.m; sourceTree = "<group>"; };
 		D0E5D846171DF0FA0041E777 /* PINExampleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PINExampleView.h; sourceTree = "<group>"; };
 		D0E5D847171DF0FA0041E777 /* PINExampleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PINExampleView.m; sourceTree = "<group>"; };
-		E0BE3BFD1ABA6B6900B516E5 /* nullability.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = nullability.h; sourceTree = "<group>"; };
+		E0BE3BFD1ABA6B6900B516E5 /* Nullability.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Nullability.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -236,7 +236,7 @@
 		D0E5D839171DF0AF0041E777 /* PINCache */ = {
 			isa = PBXGroup;
 			children = (
-				E0BE3BFD1ABA6B6900B516E5 /* nullability.h */,
+				E0BE3BFD1ABA6B6900B516E5 /* Nullability.h */,
 				D0E5D83A171DF0AF0041E777 /* PINCache.h */,
 				D0E5D83B171DF0AF0041E777 /* PINCache.m */,
 				D0E5D83C171DF0AF0041E777 /* PINDiskCache.h */,
@@ -258,7 +258,7 @@
 				662900361A66B727009C10BD /* PINCache.h in Headers */,
 				662900481A66B831009C10BD /* PINMemoryCache.h in Headers */,
 				662900471A66B831009C10BD /* PINDiskCache.h in Headers */,
-				E0BE3BFF1ABA6BD700B516E5 /* nullability.h in Headers */,
+				E0BE3BFF1ABA6BD700B516E5 /* Nullability.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -269,7 +269,7 @@
 				662900351A66B724009C10BD /* PINCache.h in Headers */,
 				662900461A66B830009C10BD /* PINMemoryCache.h in Headers */,
 				662900451A66B830009C10BD /* PINDiskCache.h in Headers */,
-				E0BE3BFE1ABA6BD000B516E5 /* nullability.h in Headers */,
+				E0BE3BFE1ABA6BD000B516E5 /* Nullability.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/PINCache.xcodeproj/project.pbxproj
+++ b/tests/PINCache.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		D0E5D844171DF0AF0041E777 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E5D83F171DF0AF0041E777 /* PINMemoryCache.m */; };
 		D0E5D845171DF0AF0041E777 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E5D83F171DF0AF0041E777 /* PINMemoryCache.m */; };
 		D0E5D848171DF0FA0041E777 /* PINExampleView.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E5D847171DF0FA0041E777 /* PINExampleView.m */; };
+		E0BE3BFE1ABA6BD000B516E5 /* nullability.h in Headers */ = {isa = PBXBuildFile; fileRef = E0BE3BFD1ABA6B6900B516E5 /* nullability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E0BE3BFF1ABA6BD700B516E5 /* nullability.h in Headers */ = {isa = PBXBuildFile; fileRef = E0BE3BFD1ABA6B6900B516E5 /* nullability.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,6 +91,7 @@
 		D0E5D83F171DF0AF0041E777 /* PINMemoryCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PINMemoryCache.m; sourceTree = "<group>"; };
 		D0E5D846171DF0FA0041E777 /* PINExampleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PINExampleView.h; sourceTree = "<group>"; };
 		D0E5D847171DF0FA0041E777 /* PINExampleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PINExampleView.m; sourceTree = "<group>"; };
+		E0BE3BFD1ABA6B6900B516E5 /* nullability.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = nullability.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -233,6 +236,7 @@
 		D0E5D839171DF0AF0041E777 /* PINCache */ = {
 			isa = PBXGroup;
 			children = (
+				E0BE3BFD1ABA6B6900B516E5 /* nullability.h */,
 				D0E5D83A171DF0AF0041E777 /* PINCache.h */,
 				D0E5D83B171DF0AF0041E777 /* PINCache.m */,
 				D0E5D83C171DF0AF0041E777 /* PINDiskCache.h */,
@@ -254,6 +258,7 @@
 				662900361A66B727009C10BD /* PINCache.h in Headers */,
 				662900481A66B831009C10BD /* PINMemoryCache.h in Headers */,
 				662900471A66B831009C10BD /* PINDiskCache.h in Headers */,
+				E0BE3BFF1ABA6BD700B516E5 /* nullability.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -264,6 +269,7 @@
 				662900351A66B724009C10BD /* PINCache.h in Headers */,
 				662900461A66B830009C10BD /* PINMemoryCache.h in Headers */,
 				662900451A66B830009C10BD /* PINDiskCache.h in Headers */,
+				E0BE3BFE1ABA6BD000B516E5 /* nullability.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Nullability annotations is more friendly to Swift. Not break compatibility for Xcode less than 6.3.
