### PR TITLE
Add readBlock to objectForKey & writeBlock to setObject:forKey:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,20 @@
 *.perspectivev3
 *.xcworkspace
 xcuserdata
+!default.pbxuser
+!default.mode1v3
+!default.mode2v3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+
+# AppCode
+.idea/
 
 #Ignore textmate build errors
 *.tm_build_errors

--- a/PINCache/PINCache.h
+++ b/PINCache/PINCache.h
@@ -116,7 +116,7 @@ typedef id (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL *fileURL);
  @param block A block to be executed concurrently when the object is available.
  */
 - (void)objectForKey:(NSString *)key block:(nonnull PINCacheObjectBlock)block;
-- (void)objectForKey:(NSString *)key readBlock:(nonnull PINCacheReadBlock)readBlock block:(nonnull PINCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key readBlock:(nullable PINCacheReadBlock)readBlock block:(nonnull PINCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
@@ -127,7 +127,7 @@ typedef id (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL *fileURL);
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
-- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nonnull PINCacheWriteBlock)writeBlock block:(nullable PINCacheObjectBlock)block;
+- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nullable PINCacheWriteBlock)writeBlock block:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed
@@ -167,7 +167,7 @@ typedef id (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL *fileURL);
  @result The object for the specified key.
  */
 - (id)objectForKey:(NSString *)key;
-- (id)objectForKey:(NSString *)key readBlock:(nonnull PINCacheReadBlock)readBlock;
+- (id)objectForKey:(NSString *)key readBlock:(nullable PINCacheReadBlock)readBlock;
 
 /**
  Stores an object in the cache for the specified key. This method blocks the calling thread until the object has been set.
@@ -178,7 +178,7 @@ typedef id (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL *fileURL);
  @param key A key to associate with the object. This string will be copied.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
-- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nonnull PINCacheWriteBlock)writeBlock;
+- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nullable PINCacheWriteBlock)writeBlock;
 
 /**
  Removes the object for the specified key. This method blocks the calling thread until the object

--- a/PINCache/PINCache.h
+++ b/PINCache/PINCache.h
@@ -23,6 +23,10 @@ typedef void (^PINCacheBlock)(PINCache *cache);
 
 typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullable object);
 
+typedef BOOL (^PINCacheWriteBlock)(PINCache *cache, NSString *key, NSURL *fileURL, id object);
+typedef id (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL *fileURL);
+
+
 /**
  `PINCache` is a thread safe key/value store designed for persisting temporary objects that are expensive to
  reproduce, such as downloaded data or the results of slow processing. It is comprised of two self-similar
@@ -111,7 +115,8 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  @param key The key associated with the requested object.
  @param block A block to be executed concurrently when the object is available.
  */
-- (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key block:(nonnull PINCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key readBlock:(nonnull PINCacheReadBlock)readBlock block:(nonnull PINCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
@@ -122,6 +127,7 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
+- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nonnull PINCacheWriteBlock)writeBlock block:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed
@@ -161,6 +167,7 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  @result The object for the specified key.
  */
 - (id)objectForKey:(NSString *)key;
+- (id)objectForKey:(NSString *)key readBlock:(nonnull PINCacheReadBlock)readBlock;
 
 /**
  Stores an object in the cache for the specified key. This method blocks the calling thread until the object has been set.
@@ -171,6 +178,7 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  @param key A key to associate with the object. This string will be copied.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
+- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nonnull PINCacheWriteBlock)writeBlock;
 
 /**
  Removes the object for the specified key. This method blocks the calling thread until the object

--- a/PINCache/PINCache.h
+++ b/PINCache/PINCache.h
@@ -141,7 +141,7 @@ typedef id __nullable (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
- passed block after the object has been stored, potentially in parallel with other blocks on the <queue>.
+ passed block after the object has been stored, potentially in parallel with other blocks on the <concurrentQueue>.
  The writeBlock is passed on to the disk cache and used to write the object to disk.
 
  @param object An object to store in the cache.

--- a/PINCache/PINCache.h
+++ b/PINCache/PINCache.h
@@ -115,7 +115,7 @@ typedef id __nullable (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL
  @param key The key associated with the requested object.
  @param block A block to be executed concurrently when the object is available.
  */
-- (void)objectForKey:(NSString *)key block:(nonnull PINCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block;
 
 
 /**
@@ -127,7 +127,7 @@ typedef id __nullable (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL
  @param readBlock A block to be executed to read the object from disk.
  @param block A block to be executed concurrently when the object is available.
  */
-- (void)objectForKey:(NSString *)key readBlock:(nullable PINCacheReadBlock)readBlock block:(nonnull PINCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key readBlock:(nullable PINCacheReadBlock)readBlock block:(PINCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the

--- a/PINCache/PINCache.h
+++ b/PINCache/PINCache.h
@@ -23,8 +23,8 @@ typedef void (^PINCacheBlock)(PINCache *cache);
 
 typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullable object);
 
-typedef BOOL (^PINCacheWriteBlock)(PINCache *cache, NSString *key, NSURL *fileURL, id object);
-typedef id (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL *fileURL);
+typedef BOOL (^PINCacheWriteBlock)(PINCache *cache, NSString *key, NSURL *fileURL, id __nonnull object);
+typedef id __nullable (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL *fileURL);
 
 
 /**
@@ -116,6 +116,17 @@ typedef id (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL *fileURL);
  @param block A block to be executed concurrently when the object is available.
  */
 - (void)objectForKey:(NSString *)key block:(nonnull PINCacheObjectBlock)block;
+
+
+/**
+ Retrieves the object for the specified key. This method returns immediately and executes the passed
+ block after the object is available, potentially in parallel with other blocks on the <concurrentQueue>.
+ The readBlock is passed on to the disk cache and used to read the object from disk.
+ 
+ @param key The key associated with the requested object.
+ @param readBlock A block to be executed to read the object from disk.
+ @param block A block to be executed concurrently when the object is available.
+ */
 - (void)objectForKey:(NSString *)key readBlock:(nullable PINCacheReadBlock)readBlock block:(nonnull PINCacheObjectBlock)block;
 
 /**
@@ -127,6 +138,17 @@ typedef id (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL *fileURL);
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
+
+/**
+ Stores an object in the cache for the specified key. This method returns immediately and executes the
+ passed block after the object has been stored, potentially in parallel with other blocks on the <queue>.
+ The writeBlock is passed on to the disk cache and used to write the object to disk.
+
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param writeBlock A block to be executed to write the object to disk.
+ @param block A block to be executed concurrently after the object has been stored, or nil.
+ */
 - (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nullable PINCacheWriteBlock)writeBlock block:(nullable PINCacheObjectBlock)block;
 
 /**
@@ -167,6 +189,16 @@ typedef id (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL *fileURL);
  @result The object for the specified key.
  */
 - (id)objectForKey:(NSString *)key;
+
+/**
+ Retrieves the object for the specified key. This method blocks the calling thread until the object is available.
+ The readBlock is passed on to the disk cache and used to read the object from disk.
+ 
+ @see objectForKey:block:
+ @param key The key associated with the object.
+ @param readBlock A block to be executed to read the object from disk.
+ @result The object for the specified key.
+ */
 - (id)objectForKey:(NSString *)key readBlock:(nullable PINCacheReadBlock)readBlock;
 
 /**
@@ -178,6 +210,16 @@ typedef id (^PINCacheReadBlock)(PINCache *cache, NSString *key, NSURL *fileURL);
  @param key A key to associate with the object. This string will be copied.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
+
+/**
+ Stores an object in the cache for the specified key. This method blocks the calling thread until the object has been set.
+ The writeBlock is passed on to the disk cache and used to write the object to disk.
+ 
+ @see setObject:forKey:block:
+ @param object An object to store in the cache.
+ @param writeBlock A block to be executed to write the object to disk.
+ @param key A key to associate with the object. This string will be copied.
+ */
 - (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nullable PINCacheWriteBlock)writeBlock;
 
 /**

--- a/PINCache/PINCache.m
+++ b/PINCache/PINCache.m
@@ -338,7 +338,7 @@ NSString * const PINCacheSharedName = @"PINCacheShared";
     } else {
         PINDiskCacheReadBlock diskReadBlock = nil;
         if (readBlock) {
-            diskReadBlock = ^id (PINDiskCache *cache, NSString *diskKey, NSURL *fileURL){
+            diskReadBlock = ^id (PINDiskCache *cache, NSString *key, NSURL *fileURL){
                 return readBlock(self, key, fileURL);
             };
         }
@@ -364,7 +364,7 @@ NSString * const PINCacheSharedName = @"PINCacheShared";
 
     PINDiskCacheWriteBlock diskWriteBlock = nil;
     if (writeBlock) {
-        diskWriteBlock = ^BOOL (PINDiskCache *cache, NSString *diskKey, NSURL *fileURL, id diskObject){
+        diskWriteBlock = ^BOOL (PINDiskCache *cache, NSString *key, NSURL *fileURL, id diskObject){
             return writeBlock(self, key, fileURL, object);
         };
     }

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -19,7 +19,7 @@ typedef void (^PINDiskCacheBlock)(PINDiskCache *cache);
  A callback block which provides the cache, key and object as arguments
  */
 
-typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding>  __nullable object, NSURL *fileURL);
+typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id __nullable object, NSURL *fileURL);
 
 typedef BOOL (^PINDiskCacheWriteBlock)(PINDiskCache *cache, NSString *key, NSURL *fileURL, id object);
 typedef id (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *fileURL);
@@ -193,8 +193,8 @@ typedef id (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *f
  @param key The key associated with the requested object.
  @param block A block to be executed serially when the object is available.
  */
-- (void)objectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
-- (void)objectForKey:(NSString *)key readBlock:(nonnull PINDiskCacheReadBlock)readBlock block:(nonnull PINCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key block:(nonnull PINDiskCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key readBlock:(nullable PINDiskCacheReadBlock)readBlock block:(nonnull PINDiskCacheObjectBlock)block;
 
 
 /**
@@ -218,7 +218,7 @@ typedef id (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *f
  @param block A block to be executed serially after the object has been stored, or nil.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
-- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nonnull PINDiskCacheWriteBlock)writeBlock block:(nullable PINCacheObjectBlock)block;
+- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nonnull PINDiskCacheWriteBlock)writeBlock block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed block

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -21,8 +21,8 @@ typedef void (^PINDiskCacheBlock)(PINDiskCache *cache);
 
 typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id __nullable object, NSURL *fileURL);
 
-typedef BOOL (^PINDiskCacheWriteBlock)(PINDiskCache *cache, NSString *key, NSURL *fileURL, id object);
-typedef id (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *fileURL);
+typedef BOOL (^PINDiskCacheWriteBlock)(PINDiskCache *cache, NSString *key, NSURL *fileURL, id __nonnull object);
+typedef id __nullable (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *fileURL);
 
 
 /**
@@ -194,6 +194,18 @@ typedef id (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *f
  @param block A block to be executed serially when the object is available.
  */
 - (void)objectForKey:(NSString *)key block:(nonnull PINDiskCacheObjectBlock)block;
+
+/**
+ Retrieves the object for the specified key. This method returns immediately and executes the passed
+ block as soon as the object is available on the serial <sharedQueue>.
+ The readBlock is used to read the object from disk.
+ 
+ @warning The fileURL is only valid for the duration of this block, do not use it after the block ends.
+ 
+ @param key The key associated with the requested object.
+ @param readBlock A block to be executed to read the object from disk.
+ @param block A block to be executed serially when the object is available.
+ */
 - (void)objectForKey:(NSString *)key readBlock:(nullable PINDiskCacheReadBlock)readBlock block:(nonnull PINDiskCacheObjectBlock)block;
 
 
@@ -218,6 +230,17 @@ typedef id (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *f
  @param block A block to be executed serially after the object has been stored, or nil.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+
+/**
+ Stores an object in the cache for the specified key. This method returns immediately and executes the
+ passed block as soon as the object has been stored.
+ The writeBlock is used to write the object to disk.
+ 
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param writeBlock A block to be executed to write the object to disk.
+ @param block A block to be executed serially after the object has been stored, or nil.
+ */
 - (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nullable PINDiskCacheWriteBlock)writeBlock block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
@@ -297,6 +320,17 @@ typedef id (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *f
  @result The object for the specified key.
  */
 - (id <NSCoding>)objectForKey:(NSString *)key;
+
+/**
+ Retrieves the object for the specified key. This method blocks the calling thread until the
+ object is available.
+ The readBlock is passed on to the disk cache and used to read the object from disk.
+
+ @see objectForKey:block:
+ @param key The key associated with the object.
+ @param readBlock A block to be executed to read the object from disk.
+ @result The object for the specified key.
+ */
 - (id)objectForKey:(NSString *)key readBlock:(nullable PINDiskCacheReadBlock)readBlock;
 
 /**
@@ -319,6 +353,17 @@ typedef id (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *f
  @param key A key to associate with the object. This string will be copied.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
+
+/**
+ Stores an object in the cache for the specified key. This method blocks the calling thread until
+ the object has been stored.
+ The writeBlock is passed on to the disk cache and used to write the object to disk.
+ 
+ @see setObject:forKey:block:
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param writeBlock A block to be executed to write the object to disk.
+ */
 - (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nullable PINDiskCacheWriteBlock)writeBlock;
 
 /**

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -193,7 +193,7 @@ typedef id __nullable (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *ke
  @param key The key associated with the requested object.
  @param block A block to be executed serially when the object is available.
  */
-- (void)objectForKey:(NSString *)key block:(nonnull PINDiskCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Retrieves the object for the specified key. This method returns immediately and executes the passed
@@ -206,7 +206,7 @@ typedef id __nullable (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *ke
  @param readBlock A block to be executed to read the object from disk.
  @param block A block to be executed serially when the object is available.
  */
-- (void)objectForKey:(NSString *)key readBlock:(nullable PINDiskCacheReadBlock)readBlock block:(nonnull PINDiskCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key readBlock:(nullable PINDiskCacheReadBlock)readBlock block:(nullable PINDiskCacheObjectBlock)block;
 
 
 /**

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -218,7 +218,7 @@ typedef id (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *f
  @param block A block to be executed serially after the object has been stored, or nil.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
-- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nonnull PINDiskCacheWriteBlock)writeBlock block:(nullable PINDiskCacheObjectBlock)block;
+- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nullable PINDiskCacheWriteBlock)writeBlock block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed block
@@ -297,7 +297,7 @@ typedef id (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *f
  @result The object for the specified key.
  */
 - (id <NSCoding>)objectForKey:(NSString *)key;
-- (id)objectForKey:(NSString *)key readBlock:(nonnull PINDiskCacheReadBlock)readBlock;
+- (id)objectForKey:(NSString *)key readBlock:(nullable PINDiskCacheReadBlock)readBlock;
 
 /**
  Retrieves the file URL for the specified key. This method blocks the calling thread until the
@@ -319,7 +319,7 @@ typedef id (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *f
  @param key A key to associate with the object. This string will be copied.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
-- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nonnull PINDiskCacheWriteBlock)writeBlock;
+- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nullable PINDiskCacheWriteBlock)writeBlock;
 
 /**
  Removes the object for the specified key. This method blocks the calling thread until the object

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -17,6 +17,7 @@ typedef void (^PINDiskCacheBlock)(PINDiskCache *cache);
 
 /**
  A callback block which provides the cache, key and object as arguments
+ Important: when read/write blocks not used object should conform to NSCoding.
  */
 
 typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id __nullable object, NSURL *fileURL);

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -21,6 +21,10 @@ typedef void (^PINDiskCacheBlock)(PINDiskCache *cache);
 
 typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding>  __nullable object, NSURL *fileURL);
 
+typedef BOOL (^PINDiskCacheWriteBlock)(PINDiskCache *cache, NSString *key, NSURL *fileURL, id object);
+typedef id (^PINDiskCacheReadBlock)(PINDiskCache *cache, NSString *key, NSURL *fileURL);
+
+
 /**
  `PINDiskCache` is a thread safe key/value store backed by the file system. It accepts any object conforming
  to the `NSCoding` protocol, which includes the basic Foundation data types and collection classes and also
@@ -190,6 +194,8 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param block A block to be executed serially when the object is available.
  */
 - (void)objectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key readBlock:(nonnull PINDiskCacheReadBlock)readBlock block:(nonnull PINCacheObjectBlock)block;
+
 
 /**
  Retrieves the fileURL for the specified key without actually reading the data from disk. This method
@@ -212,6 +218,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param block A block to be executed serially after the object has been stored, or nil.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nonnull PINDiskCacheWriteBlock)writeBlock block:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed block
@@ -290,6 +297,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @result The object for the specified key.
  */
 - (id <NSCoding>)objectForKey:(NSString *)key;
+- (id)objectForKey:(NSString *)key readBlock:(nonnull PINDiskCacheReadBlock)readBlock;
 
 /**
  Retrieves the file URL for the specified key. This method blocks the calling thread until the
@@ -311,6 +319,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param key A key to associate with the object. This string will be copied.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
+- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(nonnull PINDiskCacheWriteBlock)writeBlock;
 
 /**
  Removes the object for the specified key. This method blocks the calling thread until the object

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -598,6 +598,11 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     return [self objectForKey:key fileURL:nil readBlock:nil];
 }
 
+- (id)objectForKey:(NSString *)key readBlock:(PINDiskCacheReadBlock)readBlock
+{
+    return [self objectForKey:key fileURL:nil readBlock:readBlock];
+}
+
 - (id <NSCoding>)objectForKey:(NSString *)key fileURL:(NSURL **)outFileURL readBlock:(PINDiskCacheReadBlock)readBlock
 {
     NSDate *now = [[NSDate alloc] init];
@@ -661,6 +666,11 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key
 {
     [self setObject:object forKey:key fileURL:nil writeBlock:nil];
+}
+
+- (void)setObject:(id)object forKey:(NSString *)key writeBlock:(PINDiskCacheWriteBlock)writeBlock
+{
+    [self setObject:object forKey:key fileURL:nil writeBlock:writeBlock];
 }
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key fileURL:(NSURL **)outFileURL writeBlock:(PINDiskCacheWriteBlock)writeBlock {

--- a/tests/PINCache.xcodeproj/xcshareddata/xcschemes/PINCacheTests.xcscheme
+++ b/tests/PINCache.xcodeproj/xcshareddata/xcschemes/PINCacheTests.xcscheme
@@ -8,7 +8,7 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "NO"
+            buildForRunning = "YES"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">

--- a/tests/PINCache.xcodeproj/xcshareddata/xcschemes/PINCacheTests.xcscheme
+++ b/tests/PINCache.xcodeproj/xcshareddata/xcschemes/PINCacheTests.xcscheme
@@ -8,7 +8,7 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">

--- a/tests/PINCache.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/tests/PINCache.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -28,16 +28,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D07F1ED1171AFB7A001DBA02"
-               BuildableName = "PINCacheTests.xctest"
-               BlueprintName = "PINCacheTests"
-               ReferencedContainer = "container:PINCache.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/tests/PINCache.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/tests/PINCache.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -28,7 +28,26 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D07F1ED1171AFB7A001DBA02"
+               BuildableName = "PINCacheTests.xctest"
+               BlueprintName = "PINCacheTests"
+               ReferencedContainer = "container:PINCache.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6629FFEC1A66B512009C10BD"
+            BuildableName = "PINCache.framework"
+            BlueprintName = "iOS"
+            ReferencedContainer = "container:PINCache.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"


### PR DESCRIPTION
Generally this is a merge of https://github.com/tumblr/TMCache/pull/30/commits to PINCache. 
Read & Write blocks are quite useful when object isn't compatible with NSCoding or manual action needs to be performed