### PR TITLE
Invalid task ids used for expiration handlers. #13

### DIFF
--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -17,7 +17,7 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
 
 @interface PINBackgroundTask : NSObject
 @property (atomic, assign) UIBackgroundTaskIdentifier taskID;
-- (void)start;
++ (instancetype)start;
 - (void)end;
 @end
 
@@ -215,8 +215,7 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
 
 + (void)emptyTrash
 {
-    PINBackgroundTask *task = [[PINBackgroundTask alloc] init];
-    [task start];
+    PINBackgroundTask *task = [PINBackgroundTask start];
     
     dispatch_async([self sharedTrashQueue], ^{
         NSError *error = nil;
@@ -653,8 +652,7 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     if (!key || !object)
         return;
     
-    PINBackgroundTask *task = [[PINBackgroundTask alloc] init];
-    [task start];
+    PINBackgroundTask *task = [PINBackgroundTask start];
     
     NSURL *fileURL = nil;
     
@@ -706,8 +704,7 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     if (!key)
         return;
     
-    PINBackgroundTask *task = [[PINBackgroundTask alloc] init];
-    [task start];
+    PINBackgroundTask *task = [PINBackgroundTask start];
     
     NSURL *fileURL = nil;
     
@@ -730,8 +727,7 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
         return;
     }
     
-    PINBackgroundTask *task = [[PINBackgroundTask alloc] init];
-    [task start];
+    PINBackgroundTask *task = [PINBackgroundTask start];
     
     [self lock];
         [self trimDiskToSize:trimByteCount];
@@ -750,8 +746,7 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
         return;
     }
     
-    PINBackgroundTask *task = [[PINBackgroundTask alloc] init];
-    [task start];
+    PINBackgroundTask *task = [PINBackgroundTask start];
     
     [self lock];
         [self trimDiskToDate:trimDate];
@@ -767,8 +762,7 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
         return;
     }
     
-    PINBackgroundTask *task = [[PINBackgroundTask alloc] init];
-    [task start];
+    PINBackgroundTask *task = [PINBackgroundTask start];
     
     [self lock];
         [self trimDiskToSizeByDate:trimByteCount];
@@ -779,8 +773,7 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
 
 - (void)removeAllObjects
 {
-    PINBackgroundTask *task = [[PINBackgroundTask alloc] init];
-    [task start];
+    PINBackgroundTask *task = [PINBackgroundTask start];
     
     [self lock];
         if (self->_willRemoveAllObjectsBlock)
@@ -807,8 +800,7 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     if (!block)
         return;
     
-    PINBackgroundTask *task = [[PINBackgroundTask alloc] init];
-    [task start];
+    PINBackgroundTask *task = [PINBackgroundTask start];
     
     [self lock];
         NSArray *keysSortedByDate = [self->_dates keysSortedByValueUsingSelector:@selector(compare:)];
@@ -1057,17 +1049,17 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     return self;
 }
 
-- (void)start
++ (instancetype)start
 {
+    PINBackgroundTask *task = [[self alloc] init];
 #if !defined(PIN_APP_EXTENSIONS)
-    __weak PINBackgroundTask *weakSelf = self;
-    self.taskID = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
-        PINBackgroundTask *strongSelf = weakSelf;
-        UIBackgroundTaskIdentifier taskID = strongSelf.taskID;
-        strongSelf.taskID = UIBackgroundTaskInvalid;
+    task.taskID = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+        UIBackgroundTaskIdentifier taskID = task.taskID;
+        task.taskID = UIBackgroundTaskInvalid;
         [[UIApplication sharedApplication] endBackgroundTask:taskID];
     }];
 #endif
+    return task;
 }
 
 - (void)end

--- a/tests/PINCache.xcodeproj/project.pbxproj
+++ b/tests/PINCache.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		D07F1EC2171AFB7A001DBA02 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D07F1EC1171AFB7A001DBA02 /* main.m */; };
 		D07F1EC6171AFB7A001DBA02 /* PINAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D07F1EC5171AFB7A001DBA02 /* PINAppDelegate.m */; };
 		D07F1ECC171AFB7A001DBA02 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D07F1ECB171AFB7A001DBA02 /* Default-568h@2x.png */; };
-		D07F1ED4171AFB7A001DBA02 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D07F1ED3171AFB7A001DBA02 /* SenTestingKit.framework */; };
 		D07F1ED5171AFB7A001DBA02 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D07F1EB5171AFB7A001DBA02 /* UIKit.framework */; };
 		D07F1ED6171AFB7A001DBA02 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D07F1EB7171AFB7A001DBA02 /* Foundation.framework */; };
 		D07F1EE1171AFB7A001DBA02 /* PINCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D07F1EE0171AFB7A001DBA02 /* PINCacheTests.m */; };
@@ -79,7 +78,6 @@
 		D07F1EC5171AFB7A001DBA02 /* PINAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINAppDelegate.m; sourceTree = "<group>"; };
 		D07F1ECB171AFB7A001DBA02 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		D07F1ED2171AFB7A001DBA02 /* PINCacheTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PINCacheTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D07F1ED3171AFB7A001DBA02 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		D07F1EDB171AFB7A001DBA02 /* PINCacheTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "PINCacheTests-Info.plist"; sourceTree = "<group>"; };
 		D07F1EDF171AFB7A001DBA02 /* PINCacheTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheTests.h; sourceTree = "<group>"; };
 		D07F1EE0171AFB7A001DBA02 /* PINCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PINCacheTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -123,7 +121,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D07F1ED4171AFB7A001DBA02 /* SenTestingKit.framework in Frameworks */,
 				D07F1ED5171AFB7A001DBA02 /* UIKit.framework in Frameworks */,
 				D07F1ED6171AFB7A001DBA02 /* Foundation.framework in Frameworks */,
 			);
@@ -195,7 +192,6 @@
 				D07F1EB5171AFB7A001DBA02 /* UIKit.framework */,
 				D07F1EB7171AFB7A001DBA02 /* Foundation.framework */,
 				D07F1EB9171AFB7A001DBA02 /* CoreGraphics.framework */,
-				D07F1ED3171AFB7A001DBA02 /* SenTestingKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -355,7 +351,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = TM;
-				LastTestingUpgradeCheck = 0620;
+				LastTestingUpgradeCheck = 0640;
 				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = Tumblr;
 				TargetAttributes = {


### PR DESCRIPTION
This should fix two issues:
- Because taskID was being captured before being set, the expiration handler had an invalid taskID.
- If the expiration handler was called, and then PINCacheEndBackgroundTask was called, it would try to end a task that had already ended.

The second case is less of an issue because I don't see it causing any problems. I've used an atomic getter / setter for taskID which should make it far less likely for there to be a race condition where endBackgroundTask is called twice with the same taskID. However it's still possible. Since this just seems to generate warnings, this seems better than the overhead of introducing a lock of some sort.