### PR TITLE
Fix PINDiskCache byteCount tracking

### DIFF
--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -675,6 +675,10 @@ NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
             
             NSNumber *diskFileSize = [values objectForKey:NSURLTotalFileAllocatedSizeKey];
             if (diskFileSize) {
+                NSNumber *prevDiskFileSize = [self->_sizes objectForKey:key];
+                if (prevDiskFileSize) {
+                    self.byteCount = self->_byteCount - [prevDiskFileSize unsignedIntegerValue];
+                }
                 [self->_sizes setObject:diskFileSize forKey:key];
                 self.byteCount = self->_byteCount + [diskFileSize unsignedIntegerValue]; // atomic
             }

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -241,6 +241,19 @@ NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     XCTAssertTrue(self.cache.diskByteCount > 0, @"disk cache byte count was not greater than zero");
 }
 
+- (void)testDiskByteCountWithExistingKey
+{
+    [self.cache setObject:[self image] forKey:@"image"];
+    NSUInteger initialDiskByteCount = self.cache.diskByteCount;
+    [self.cache setObject:[self image] forKey:@"image"];
+
+    XCTAssertTrue(self.cache.diskByteCount == initialDiskByteCount, @"disk cache byte count should not change by adding object with existing key and size");
+
+    [self.cache setObject:[self image] forKey:@"image2"];
+
+    XCTAssertTrue(self.cache.diskByteCount > initialDiskByteCount, @"disk cache byte count should increase with new key and object added to disk cache");
+}
+
 - (void)testOneThousandAndOneWrites
 {
     NSUInteger max = 1001;


### PR DESCRIPTION
Decrease byteCount by file's previous byteCount if updating object already in cache.