### PR TITLE
Add weak cache to keep references to retained objects

### DIFF
--- a/PINCache/PINMemoryCache.m
+++ b/PINCache/PINMemoryCache.m
@@ -59,7 +59,9 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
         _concurrentQueue = dispatch_queue_create([queueName UTF8String], DISPATCH_QUEUE_CONCURRENT);
 
         _dictionary = [[NSMutableDictionary alloc] init];
-        _weakMapTable = [NSMapTable strongToWeakObjectsMapTable];
+        if ([[NSMapTable class] respondsToSelector:@selector(strongToWeakObjectsMapTable)]) {
+            _weakMapTable = [NSMapTable strongToWeakObjectsMapTable];
+        }
         _dates = [[NSMutableDictionary alloc] init];
         _costs = [[NSMutableDictionary alloc] init];
 

--- a/PINCache/PINMemoryCache.m
+++ b/PINCache/PINMemoryCache.m
@@ -19,6 +19,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 @property (assign, nonatomic) dispatch_semaphore_t lockSemaphore;
 #endif
 @property (strong, nonatomic) NSMutableDictionary *dictionary;
+@property (strong, nonatomic) NSMapTable *weakMapTable;
 @property (strong, nonatomic) NSMutableDictionary *dates;
 @property (strong, nonatomic) NSMutableDictionary *costs;
 @end
@@ -58,6 +59,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
         _concurrentQueue = dispatch_queue_create([queueName UTF8String], DISPATCH_QUEUE_CONCURRENT);
 
         _dictionary = [[NSMutableDictionary alloc] init];
+        _weakMapTable = [NSMapTable strongToWeakObjectsMapTable];
         _dates = [[NSMutableDictionary alloc] init];
         _costs = [[NSMutableDictionary alloc] init];
 
@@ -388,11 +390,17 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     
     [self lock];
         id object = _dictionary[key];
+
+        if (!object) {
+            object = [_weakMapTable objectForKey:key];
+        }
     [self unlock];
         
     if (object) {
         [self lock];
             _dates[key] = [[NSDate alloc] init];
+            _dictionary[key] = object;
+            [_weakMapTable setObject:object forKey:key];
         [self unlock];
     }
 
@@ -420,6 +428,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     
     [self lock];
         _dictionary[key] = object;
+        [_weakMapTable setObject:object forKey:key];
         _dates[key] = [[NSDate alloc] init];
         _costs[key] = @(cost);
         

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -497,6 +497,9 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     [self.cache.memoryCache setAgeLimit:1];
     [self.cache.diskCache setAgeLimit:1];
     
+    memObj = nil;
+    diskObj = nil;
+
     dispatch_group_enter(group);
     [self.cache.memoryCache objectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -184,11 +184,23 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
 {
     NSString *key1 = @"key1";
     NSString *key2 = @"key2";
+
+    NSString *value1 = nil;
+    NSString *value2 = nil;
+
+    @autoreleasepool {
+        value1 = [NSString stringWithFormat:@"value for %@", key1];
+        value2 = [NSString stringWithFormat:@"value for %@", key2];
+    }
+
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-    
-    [self.cache setObject:key1 forKey:key1];
-    [self.cache setObject:key2 forKey:key2];
-    
+
+    [self.cache setObject:value1 forKey:key1];
+    [self.cache setObject:value2 forKey:key2];
+
+    value1 = nil;
+    value2 = nil;
+
     [self.cache removeAllObjects:^(PINCache *cache) {
         dispatch_semaphore_signal(semaphore);
     }];
@@ -209,9 +221,20 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     NSString *key1 = @"key1";
     NSString *key2 = @"key2";
 
-    [self.cache.memoryCache setObject:key1 forKey:key1 withCost:1];
-    [self.cache.memoryCache setObject:key2 forKey:key2 withCost:2];
-    
+    NSString *value1 = nil;
+    NSString *value2 = nil;
+
+    @autoreleasepool {
+        value1 = [NSString stringWithFormat:@"value for %@", key1];
+        value2 = [NSString stringWithFormat:@"value for %@", key2];
+    }
+
+    [self.cache.memoryCache setObject:value1 forKey:key1 withCost:1];
+    [self.cache.memoryCache setObject:value2 forKey:key2 withCost:2];
+
+    value1 = nil;
+    value2 = nil;
+
     XCTAssertTrue(self.cache.memoryCache.totalCost == 3, @"memory cache total cost was incorrect");
 
     [self.cache.memoryCache trimToCost:1];
@@ -229,8 +252,19 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     NSString *key1 = @"key1";
     NSString *key2 = @"key2";
 
-    [self.cache.memoryCache setObject:key1 forKey:key1 withCost:1];
-    [self.cache.memoryCache setObject:key2 forKey:key2 withCost:2];
+    NSString *value1 = nil;
+    NSString *value2 = nil;
+
+    @autoreleasepool {
+        value1 = [NSString stringWithFormat:@"value for %@", key1];
+        value2 = [NSString stringWithFormat:@"value for %@", key2];
+    }
+
+    [self.cache.memoryCache setObject:value1 forKey:key1 withCost:1];
+    [self.cache.memoryCache setObject:value2 forKey:key2 withCost:2];
+
+    value1 = nil;
+    value2 = nil;
 
     [self.cache.memoryCache trimToCostByDate:1];
 

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -45,16 +45,12 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
 
 - (UIImage *)image
 {
-    static UIImage *image = nil;
-    
-    if (!image) {
-        NSError *error = nil;
-        NSURL *imageURL = [[NSBundle mainBundle] URLForResource:@"Default-568h@2x" withExtension:@"png"];
-        NSData *imageData = [[NSData alloc] initWithContentsOfURL:imageURL
-                                                          options:NSDataReadingUncached
-                                                            error:&error];
-        image = [[UIImage alloc] initWithData:imageData scale:2.f];
-    }
+    NSError *error = nil;
+    NSURL *imageURL = [[NSBundle mainBundle] URLForResource:@"Default-568h@2x" withExtension:@"png"];
+    NSData *imageData = [[NSData alloc] initWithContentsOfURL:imageURL
+                                                      options:NSDataReadingUncached
+                                                        error:&error];
+    UIImage *image = [[UIImage alloc] initWithData:imageData scale:2.f];
 
     NSAssert(image, @"test image does not exist");
 


### PR DESCRIPTION
The map table ensures the cache has a reference to an object still in memory, even if it has been evicted from the dictionary.