### PR TITLE
Fix variable shadowing warnings

### DIFF
--- a/PINCache/PINCache.m
+++ b/PINCache/PINCache.m
@@ -74,6 +74,8 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 #pragma mark - Public Asynchronous Methods -
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
 
 - (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
@@ -89,13 +91,13 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
         
         __weak PINCache *weakSelf = strongSelf;
         
-        [strongSelf->_memoryCache objectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+        [strongSelf->_memoryCache objectForKey:key block:^(PINMemoryCache *memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
             PINCache *strongSelf = weakSelf;
             if (!strongSelf)
                 return;
             
-            if (object) {
-                [strongSelf->_diskCache fileURLForKey:key block:^(PINDiskCache *cache, NSString *key, id <NSCoding> object, NSURL *fileURL) {
+            if (memoryCacheObject) {
+                [strongSelf->_diskCache fileURLForKey:memoryCacheKey block:^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> diskCacheObject, NSURL *fileURL) {
                     // update the access time on disk
                 }];
                 
@@ -104,30 +106,32 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
                 dispatch_async(strongSelf->_concurrentQueue, ^{
                     PINCache *strongSelf = weakSelf;
                     if (strongSelf)
-                        block(strongSelf, key, object);
+                        block(strongSelf, memoryCacheKey, memoryCacheObject);
                 });
             } else {
                 __weak PINCache *weakSelf = strongSelf;
                 
-                [strongSelf->_diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id <NSCoding> object, NSURL *fileURL) {
+                [strongSelf->_diskCache objectForKey:memoryCacheKey block:^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> diskCacheObject, NSURL *fileURL) {
                     PINCache *strongSelf = weakSelf;
                     if (!strongSelf)
                         return;
                     
-                    [strongSelf->_memoryCache setObject:object forKey:key block:nil];
+                    [strongSelf->_memoryCache setObject:diskCacheObject forKey:diskCacheKey block:nil];
                     
                     __weak PINCache *weakSelf = strongSelf;
                     
                     dispatch_async(strongSelf->_concurrentQueue, ^{
                         PINCache *strongSelf = weakSelf;
                         if (strongSelf)
-                            block(strongSelf, key, object);
+                            block(strongSelf, diskCacheKey, diskCacheObject);
                     });
                 }];
             }
         }];
     });
 }
+
+#pragma clang diagnostic pop
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
@@ -143,11 +147,11 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
         dispatch_group_enter(group);
         dispatch_group_enter(group);
         
-        memBlock = ^(PINMemoryCache *cache, NSString *key, id object) {
+        memBlock = ^(PINMemoryCache *memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
             dispatch_group_leave(group);
         };
         
-        diskBlock = ^(PINDiskCache *cache, NSString *key, id <NSCoding> object, NSURL *fileURL) {
+        diskBlock = ^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> memoryCacheObject, NSURL *memoryCacheFileURL) {
             dispatch_group_leave(group);
         };
     }
@@ -183,11 +187,11 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
         dispatch_group_enter(group);
         dispatch_group_enter(group);
         
-        memBlock = ^(PINMemoryCache *cache, NSString *key, id object) {
+        memBlock = ^(PINMemoryCache *memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
             dispatch_group_leave(group);
         };
         
-        diskBlock = ^(PINDiskCache *cache, NSString *key, id <NSCoding> object, NSURL *fileURL) {
+        diskBlock = ^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> memoryCacheObject, NSURL *memoryCacheFileURL) {
             dispatch_group_leave(group);
         };
     }

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -238,17 +238,17 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     PINBackgroundTask *task = [PINBackgroundTask start];
     
     dispatch_async([self sharedTrashQueue], ^{
-        NSError *error = nil;
+        NSError *searchTrashedItemsError = nil;
         NSArray *trashedItems = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:[self sharedTrashURL]
                                                               includingPropertiesForKeys:nil
                                                                                  options:0
-                                                                                   error:&error];
-        PINDiskCacheError(error);
+                                                                                   error:&searchTrashedItemsError];
+        PINDiskCacheError(searchTrashedItemsError);
         
         for (NSURL *trashedItemURL in trashedItems) {
-            NSError *error = nil;
-            [[NSFileManager defaultManager] removeItemAtURL:trashedItemURL error:&error];
-            PINDiskCacheError(error);
+            NSError *removeTrashedItemError = nil;
+            [[NSFileManager defaultManager] removeItemAtURL:trashedItemURL error:&removeTrashedItemError];
+            PINDiskCacheError(removeTrashedItemError);
         }
         
         [task end];

--- a/PINCache/PINMemoryCache.m
+++ b/PINCache/PINMemoryCache.m
@@ -203,8 +203,10 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 
 - (void)trimToCostLimit:(NSUInteger)limit
 {
+    NSUInteger totalCost = 0;
+    
     [self lock];
-        NSUInteger totalCost = _totalCost;
+        totalCost = _totalCost;
         NSArray *keysSortedByCost = [_costs keysSortedByValueUsingSelector:@selector(compare:)];
     [self unlock];
     
@@ -216,7 +218,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
         [self removeObjectAndExecuteBlocksForKey:key];
 
         [self lock];
-            NSUInteger totalCost = _totalCost;
+            totalCost = _totalCost;
         [self unlock];
         
         if (totalCost <= limit)
@@ -226,8 +228,10 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 
 - (void)trimToCostLimitByDate:(NSUInteger)limit
 {
+    NSUInteger totalCost = 0;
+    
     [self lock];
-        NSUInteger totalCost = _totalCost;
+        totalCost = _totalCost;
         NSArray *keysSortedByDate = [_dates keysSortedByValueUsingSelector:@selector(compare:)];
     [self unlock];
     
@@ -238,7 +242,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
         [self removeObjectAndExecuteBlocksForKey:key];
 
         [self lock];
-            NSUInteger totalCost = _totalCost;
+            totalCost = _totalCost;
         [self unlock];
         if (totalCost <= limit)
             break;


### PR DESCRIPTION
Should fix #51 

For the PINCache's objectForKey method I added a clang compiler pragma to suppress showing up the shadowing warnings. This is only for the weakSelf / strongSelf variables. There should be no other variables be shadowed anymore.

We could certainly go without the clang pragma, we should just come up with good names for all of this shadowed weakSelf / strongSelf variables than :)