### PR TITLE
Fixed bug that % is not properly escaped (PINDiskCache)

### DIFF
--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -146,10 +146,10 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     }
     
     if ([string respondsToSelector:@selector(stringByAddingPercentEncodingWithAllowedCharacters:)]) {
-        return [string stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@".:/"] invertedSet]];
+        return [string stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@".:/%"] invertedSet]];
     }
     else {
-        CFStringRef static const charsToEscape = CFSTR(".:/");
+        CFStringRef static const charsToEscape = CFSTR(".:/%");
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         CFStringRef escapedString = CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -70,8 +70,8 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
 
 - (void)testDiskCacheStringEncoding
 {
-    NSString *string = [self.cache.diskCache encodedString:@"http://www.test.de-<CoolStuff>"];
-    XCTAssertTrue([string isEqualToString:@"http%3A%2F%2Fwww%2Etest%2Ede-<CoolStuff>"]);
+    NSString *string = [self.cache.diskCache encodedString:@"http://www.test.de-<CoolStuff>?%"];
+    XCTAssertTrue([string isEqualToString:@"http%3A%2F%2Fwww%2Etest%2Ede-<CoolStuff>?%25"]);
 }
 
 - (void)testCoreProperties


### PR DESCRIPTION
The current implementation doesn't escape %, so the following code fails:

```
[self decodedString:[self encodedString:@"%"]] // nil
```
