### PR TITLE
Added TTL cache capability

### DIFF
--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -105,7 +105,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
       the cache will behave as if the object does not exist
  
  */
-@property (assign, getter=isTTLCache) BOOL ttlCache;
+@property (nonatomic, assign, getter=isTTLCache) BOOL ttlCache;
 
 #pragma mark -
 /// @name Event Blocks

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -97,6 +97,16 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  */
 @property (assign) NSTimeInterval ageLimit;
 
+/**
+ If ttlCache is YES, the cache behaves like a ttlCache. This means that once an object enters the
+ cache, it only lives as long as self.ageLimit. This has the following implications:
+    - Accessing an object in the cache does not extend that object's lifetime in the cache
+    - When attempting to access an object in the cache that has lived longer than self.ageLimit,
+      the cache will behave as if the object does not exist
+ 
+ */
+@property (assign, getter=isTTLCache) BOOL ttlCache;
+
 #pragma mark -
 /// @name Event Blocks
 

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -618,7 +618,9 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
         fileURL = [self encodedFileURLForKey:key];
         object = nil;
         
-        if ([[NSFileManager defaultManager] fileExistsAtPath:[fileURL path]]) {
+        if ([[NSFileManager defaultManager] fileExistsAtPath:[fileURL path]] &&
+            // If the cache should behave like a TTL cache, then only fetch the object if there's a valid ageLimit and  the object is still alive
+            (!self->_ttlCache || self->_ageLimit <= 0 || fabs([[_dates objectForKey:key] timeIntervalSinceDate:now]) < self->_ageLimit)) {
             @try {
                 object = [NSKeyedUnarchiver unarchiveObjectWithFile:[fileURL path]];
             }
@@ -627,8 +629,9 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
                 [[NSFileManager defaultManager] removeItemAtPath:[fileURL path] error:&error];
                 PINDiskCacheError(error);
             }
-            
+          if (!self->_ttlCache) {
             [self setFileModificationDate:now forURL:fileURL];
+          }
         }
     [self unlock];
     
@@ -827,11 +830,15 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     PINBackgroundTask *task = [PINBackgroundTask start];
     
     [self lock];
+        NSDate *now = [NSDate date];
         NSArray *keysSortedByDate = [self->_dates keysSortedByValueUsingSelector:@selector(compare:)];
         
         for (NSString *key in keysSortedByDate) {
             NSURL *fileURL = [self encodedFileURLForKey:key];
-            block(self, key, nil, fileURL);
+            // If the cache should behave like a TTL cache, then only fetch the object if there's a valid ageLimit and  the object is still alive
+            if (!self->_ttlCache || self->_ageLimit <= 0 || fabs([[_dates objectForKey:key] timeIntervalSinceDate:now]) < self->_ageLimit) {
+                block(self, key, nil, fileURL);
+            }
         }
     [self unlock];
     

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -1059,6 +1059,16 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     });
 }
 
+- (BOOL)isTTLCache {
+    BOOL isTTLCache;
+    
+    [self lock];
+        isTTLCache = _ttlCache;
+    [self unlock];
+  
+    return isTTLCache;
+}
+
 - (void)lock
 {
     dispatch_semaphore_wait(_lockSemaphore, DISPATCH_TIME_FOREVER);

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -48,6 +48,7 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
 @synthesize didRemoveAllObjectsBlock = _didRemoveAllObjectsBlock;
 @synthesize byteLimit = _byteLimit;
 @synthesize ageLimit = _ageLimit;
+@synthesize ttlCache = _ttlCache;
 
 #pragma mark - Initialization -
 
@@ -1067,6 +1068,20 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     [self unlock];
   
     return isTTLCache;
+}
+
+- (void)setTtlCache:(BOOL)ttlCache {
+    __weak PINDiskCache *weakSelf = self;
+
+    dispatch_async(_asyncQueue, ^{
+        PINDiskCache *strongSelf = weakSelf;
+        if (!strongSelf)
+            return;
+
+        [strongSelf lock];
+            strongSelf->_ttlCache = ttlCache;
+        [strongSelf unlock];
+    });
 }
 
 - (void)lock

--- a/PINCache/PINMemoryCache.h
+++ b/PINCache/PINMemoryCache.h
@@ -73,7 +73,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  the cache will behave as if the object does not exist
  
  */
-@property (assign, getter=isTTLCache) BOOL ttlCache;
+@property (nonatomic, assign, getter=isTTLCache) BOOL ttlCache;
 
 /**
  When `YES` on iOS the cache will remove all objects when the app receives a memory warning.

--- a/PINCache/PINMemoryCache.h
+++ b/PINCache/PINMemoryCache.h
@@ -66,6 +66,16 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
 @property (assign) NSTimeInterval ageLimit;
 
 /**
+ If ttlCache is YES, the cache behaves like a ttlCache. This means that once an object enters the
+ cache, it only lives as long as self.ageLimit. This has the following implications:
+ - Accessing an object in the cache does not extend that object's lifetime in the cache
+ - When attempting to access an object in the cache that has lived longer than self.ageLimit,
+ the cache will behave as if the object does not exist
+ 
+ */
+@property (assign, getter=isTTLCache) BOOL ttlCache;
+
+/**
  When `YES` on iOS the cache will remove all objects when the app receives a memory warning.
  Defaults to `YES`.
  */

--- a/PINCache/PINMemoryCache.m
+++ b/PINCache/PINMemoryCache.m
@@ -28,6 +28,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 @synthesize ageLimit = _ageLimit;
 @synthesize costLimit = _costLimit;
 @synthesize totalCost = _totalCost;
+@synthesize ttlCache = _ttlCache;
 @synthesize willAddObjectBlock = _willAddObjectBlock;
 @synthesize willRemoveObjectBlock = _willRemoveObjectBlock;
 @synthesize willRemoveAllObjectsBlock = _willRemoveAllObjectsBlock;
@@ -699,6 +700,13 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     
     return isTTLCache;
 }
+
+- (void)setTtlCache:(BOOL)ttlCache {
+    [self lock];
+        _ttlCache = ttlCache;
+    [self unlock];
+}
+
 
 - (void)lock
 {

--- a/PINCache/PINMemoryCache.m
+++ b/PINCache/PINMemoryCache.m
@@ -690,6 +690,16 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     return cost;
 }
 
+- (BOOL)isTTLCache {
+    BOOL isTTLCache;
+    
+    [self lock];
+        isTTLCache = _ttlCache;
+    [self unlock];
+    
+    return isTTLCache;
+}
+
 - (void)lock
 {
     dispatch_semaphore_wait(_lockSemaphore, DISPATCH_TIME_FOREVER);

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -519,4 +519,94 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     XCTAssert(diskObj == nil, @"should not be in disk cache");
 }
 
+- (void)testTTLCacheObjectAccess {
+    [self.cache removeAllObjects];
+    NSString *key = @"key";
+    [self.cache.memoryCache setAgeLimit:2];
+    [self.cache.diskCache setAgeLimit:2];
+    
+    
+    // The cache is going to clear at 2 seconds, set an object at 1 second, so that it misses the first cach clearing
+    sleep(1);
+    [self.cache setObject:[self image] forKey:key];
+    
+    // Wait until time 3 so that we know the object should be expired, the 1st cache clearing has happened, and the 2nd cache clearing hasn't happened yet
+    sleep(2);
+    
+    [self.cache.diskCache setTtlCache:YES];
+    [self.cache.memoryCache setTtlCache:YES];
+    
+    id memObj = [self.cache.memoryCache objectForKey:key];
+    id diskObj = [self.cache.diskCache objectForKey:key];
+
+    // If the cache is supposed to behave like a TTL cache, then the object shouldn't appear to be in the cache
+    XCTAssertNil(memObj, @"should not be in memory cache");
+    XCTAssertNil(diskObj, @"should not be in disk cache");
+
+    [self.cache.diskCache setTtlCache:NO];
+    [self.cache.memoryCache setTtlCache:NO];
+  
+    memObj = [self.cache.memoryCache objectForKey:key];
+    diskObj = [self.cache.diskCache objectForKey:key];
+
+     // If the cache is NOT supposed to behave like a TTL cache, then the object should appear to be in the cache because it hasn't been cleared yet
+    XCTAssertNotNil(memObj, @"should still be in memory cache");
+    XCTAssertNotNil(diskObj, @"should still be in disk cache");
+}
+
+- (void)testTTLCacheObjectEnumeration {
+  [self.cache removeAllObjects];
+  NSString *key = @"key";
+  [self.cache.memoryCache setAgeLimit:2];
+  [self.cache.diskCache setAgeLimit:2];
+  
+  
+  // The cache is going to clear at 2 seconds, set an object at 1 second, so that it misses the first cach clearing
+  sleep(1);
+  [self.cache setObject:[self image] forKey:key];
+  
+  // Wait until time 3 so that we know the object should be expired, the 1st cache clearing has happened, and the 2nd cache clearing hasn't happened yet
+  sleep(2);
+  
+  [self.cache.diskCache setTtlCache:YES];
+  [self.cache.memoryCache setTtlCache:YES];
+  
+  // With the TTL cache enabled, we expect enumerating over the caches to yield 0 objects
+  NSUInteger expectedObjCount = 0;
+  __block NSUInteger objCount = 0;
+  [self.cache.diskCache enumerateObjectsWithBlock:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL * _Nullable fileURL) {
+    objCount++;
+  }];
+  
+  XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", expectedObjCount);
+  
+  objCount = 0;
+  [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+    objCount++;
+  }];
+  
+  XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", expectedObjCount);
+  
+  [self.cache.diskCache setTtlCache:NO];
+  [self.cache.memoryCache setTtlCache:NO];
+
+  
+  // With the TTL cache disabled, we expect enumerating over the caches to yield 1 object each, since the 2nd cache clearing hasn't happened yet
+  expectedObjCount = 1;
+  objCount = 0;
+  [self.cache.diskCache enumerateObjectsWithBlock:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL * _Nullable fileURL) {
+    objCount++;
+  }];
+  
+  XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", expectedObjCount);
+  
+  objCount = 0;
+  [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+    objCount++;
+  }];
+  
+  XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", expectedObjCount);
+}
+
+
 @end

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -524,20 +524,36 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     NSString *key = @"key";
     [self.cache.memoryCache setAgeLimit:2];
     [self.cache.diskCache setAgeLimit:2];
-    
-    
+
+
     // The cache is going to clear at 2 seconds, set an object at 1 second, so that it misses the first cach clearing
     sleep(1);
     [self.cache setObject:[self image] forKey:key];
-    
+
     // Wait until time 3 so that we know the object should be expired, the 1st cache clearing has happened, and the 2nd cache clearing hasn't happened yet
     sleep(2);
-    
+
     [self.cache.diskCache setTtlCache:YES];
     [self.cache.memoryCache setTtlCache:YES];
-    
-    id memObj = [self.cache.memoryCache objectForKey:key];
-    id diskObj = [self.cache.diskCache objectForKey:key];
+
+    dispatch_group_t group = dispatch_group_create();
+
+    __block id memObj = nil;
+    __block id diskObj = nil;
+
+    dispatch_group_enter(group);
+    [self.cache.memoryCache objectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+        memObj = object;
+        dispatch_group_leave(group);
+    }];
+
+    dispatch_group_enter(group);
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object, NSURL *fileURL) {
+        diskObj = object;
+        dispatch_group_leave(group);
+    }];
+
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
 
     // If the cache is supposed to behave like a TTL cache, then the object shouldn't appear to be in the cache
     XCTAssertNil(memObj, @"should not be in memory cache");
@@ -545,67 +561,80 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
 
     [self.cache.diskCache setTtlCache:NO];
     [self.cache.memoryCache setTtlCache:NO];
-  
-    memObj = [self.cache.memoryCache objectForKey:key];
-    diskObj = [self.cache.diskCache objectForKey:key];
 
+    memObj = nil;
+    diskObj = nil;
+
+    dispatch_group_enter(group);
+    [self.cache.memoryCache objectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+        memObj = object;
+        dispatch_group_leave(group);
+    }];
+
+    dispatch_group_enter(group);
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object, NSURL *fileURL) {
+        diskObj = object;
+        dispatch_group_leave(group);
+    }];
+
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
      // If the cache is NOT supposed to behave like a TTL cache, then the object should appear to be in the cache because it hasn't been cleared yet
     XCTAssertNotNil(memObj, @"should still be in memory cache");
     XCTAssertNotNil(diskObj, @"should still be in disk cache");
 }
 
 - (void)testTTLCacheObjectEnumeration {
-  [self.cache removeAllObjects];
-  NSString *key = @"key";
-  [self.cache.memoryCache setAgeLimit:2];
-  [self.cache.diskCache setAgeLimit:2];
-  
-  
-  // The cache is going to clear at 2 seconds, set an object at 1 second, so that it misses the first cach clearing
-  sleep(1);
-  [self.cache setObject:[self image] forKey:key];
-  
-  // Wait until time 3 so that we know the object should be expired, the 1st cache clearing has happened, and the 2nd cache clearing hasn't happened yet
-  sleep(2);
-  
-  [self.cache.diskCache setTtlCache:YES];
-  [self.cache.memoryCache setTtlCache:YES];
-  
-  // With the TTL cache enabled, we expect enumerating over the caches to yield 0 objects
-  NSUInteger expectedObjCount = 0;
-  __block NSUInteger objCount = 0;
-  [self.cache.diskCache enumerateObjectsWithBlock:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL * _Nullable fileURL) {
-    objCount++;
-  }];
-  
-  XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", expectedObjCount);
-  
-  objCount = 0;
-  [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
-    objCount++;
-  }];
-  
-  XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", expectedObjCount);
-  
-  [self.cache.diskCache setTtlCache:NO];
-  [self.cache.memoryCache setTtlCache:NO];
+    [self.cache removeAllObjects];
+    NSString *key = @"key";
+    [self.cache.memoryCache setAgeLimit:2];
+    [self.cache.diskCache setAgeLimit:2];
 
-  
-  // With the TTL cache disabled, we expect enumerating over the caches to yield 1 object each, since the 2nd cache clearing hasn't happened yet
-  expectedObjCount = 1;
-  objCount = 0;
-  [self.cache.diskCache enumerateObjectsWithBlock:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL * _Nullable fileURL) {
-    objCount++;
-  }];
-  
-  XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", expectedObjCount);
-  
-  objCount = 0;
-  [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
-    objCount++;
-  }];
-  
-  XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", expectedObjCount);
+
+    // The cache is going to clear at 2 seconds, set an object at 1 second, so that it misses the first cach clearing
+    sleep(1);
+    [self.cache setObject:[self image] forKey:key];
+
+    // Wait until time 3 so that we know the object should be expired, the 1st cache clearing has happened, and the 2nd cache clearing hasn't happened yet
+    sleep(2);
+
+    [self.cache.diskCache setTtlCache:YES];
+    [self.cache.memoryCache setTtlCache:YES];
+
+    // With the TTL cache enabled, we expect enumerating over the caches to yield 0 objects
+    NSUInteger expectedObjCount = 0;
+    __block NSUInteger objCount = 0;
+    [self.cache.diskCache enumerateObjectsWithBlock:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL * _Nullable fileURL) {
+      objCount++;
+    }];
+
+    XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", expectedObjCount);
+
+    objCount = 0;
+    [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+      objCount++;
+    }];
+
+    XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", expectedObjCount);
+
+    [self.cache.diskCache setTtlCache:NO];
+    [self.cache.memoryCache setTtlCache:NO];
+
+
+    // With the TTL cache disabled, we expect enumerating over the caches to yield 1 object each, since the 2nd cache clearing hasn't happened yet
+    expectedObjCount = 1;
+    objCount = 0;
+    [self.cache.diskCache enumerateObjectsWithBlock:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL * _Nullable fileURL) {
+      objCount++;
+    }];
+
+    XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", expectedObjCount);
+
+    objCount = 0;
+    [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+      objCount++;
+    }];
+
+    XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", expectedObjCount);
 }
 
 


### PR DESCRIPTION
In #32, I wanted to add what basically amounts to the ability to make the caches behave like a TTL cache. I've done this with tests, which I think clearly illustrate the behavior I was going for here. I'm pretty open to discussion on this, and I've made sure that this is opt-in, so existing behavior of the caches should be unaffected.