### PR TITLE
Remove PIN_APP_EXTENSION requirement

### DIFF
--- a/PINCache.podspec
+++ b/PINCache.podspec
@@ -1,24 +1,25 @@
 Pod::Spec.new do |s|
-  s.name          = 'PINCache'
-  s.version       = '2.2.1'
-  s.source_files  = 'PINCache/*.{h,m}'
-  s.homepage      = 'https://github.com/pinterest/PINCache'
-  s.summary       = 'Fast, thread safe, parallel object cache for iOS and OS X.'
-  s.authors       = { 'Garrett Moon' => 'garrett@pinterest.com', 'Justin Ouellette' => 'jstn@tumblr.com' }
-  s.source        = { :git => 'https://github.com/pinterest/PINCache.git', :tag => "#{s.version}" }
-  s.license       = { :type => 'Apache 2.0', :file => 'LICENSE.txt' }
-  s.requires_arc  = true
-  s.frameworks    = 'Foundation'
-  s.ios.weak_frameworks   = 'UIKit'
-  s.osx.weak_frameworks   = 'AppKit'
-  s.ios.deployment_target = '5.0'
-  s.osx.deployment_target = '10.7'
-  s.tvos.deployment_target = '9.0'
+  s.name                      = 'PINCache'
+  s.version                   = '2.2.1'
+  s.source_files              = 'PINCache/*.{h,m}'
+  s.private_header_files      = 'PINCache/PIN*BackgroundTask.h'
+  s.homepage                  = 'https://github.com/pinterest/PINCache'
+  s.summary                   = 'Fast, thread safe, parallel object cache for iOS and OS X.'
+  s.authors                   = { 'Garrett Moon' => 'garrett@pinterest.com', 'Justin Ouellette' => 'jstn@tumblr.com' }
+  s.source                    = { :git => 'https://github.com/pinterest/PINCache.git', :tag => "#{s.version}" }
+  s.license                   = { :type => 'Apache 2.0', :file => 'LICENSE.txt' }
+  s.requires_arc              = true
+  s.frameworks                = 'Foundation'
+  s.ios.weak_frameworks       = 'UIKit'
+  s.osx.weak_frameworks       = 'AppKit'
+  s.ios.deployment_target     = '5.0'
+  s.osx.deployment_target     = '10.7'
+  s.tvos.deployment_target    = '9.0'
   s.watchos.deployment_target = '2.0'
   pch_PIN = <<-EOS
 #ifndef TARGET_OS_WATCH
   #define TARGET_OS_WATCH 0
 #endif
 EOS
-  s.prefix_header_contents = pch_PIN
+  s.prefix_header_contents    = pch_PIN
 end

--- a/PINCache/PINApplicationBackgroundTask.h
+++ b/PINCache/PINApplicationBackgroundTask.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Availability.h>
 #import "PINBackgroundTask.h"
 
 #if !TARGET_OS_WATCH

--- a/PINCache/PINApplicationBackgroundTask.h
+++ b/PINCache/PINApplicationBackgroundTask.h
@@ -1,0 +1,18 @@
+//
+//  PINApplicationBackgroundTask.h
+//  PINCache
+//
+//  Created by Ben Asher on 2/11/16.
+//  Copyright © 2016 Pinterest. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Availability.h>
+#import "PINBackgroundTask.h"
+
+#if !TARGET_OS_WATCH
+NS_EXTENSION_UNAVAILABLE_IOS("This is a concrete PINBackgroundTask that depends on UIApplication, which cannot be used in extensions")
+@interface PINApplicationBackgroundTask : NSObject <PINBackgroundTask>
+
+@end
+#endif

--- a/PINCache/PINApplicationBackgroundTask.h
+++ b/PINCache/PINApplicationBackgroundTask.h
@@ -9,9 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "PINBackgroundTask.h"
 
-#if !TARGET_OS_WATCH
 NS_EXTENSION_UNAVAILABLE_IOS("This is a concrete PINBackgroundTask that depends on UIApplication, which cannot be used in extensions")
 @interface PINApplicationBackgroundTask : NSObject <PINBackgroundTask>
 
 @end
-#endif

--- a/PINCache/PINApplicationBackgroundTask.m
+++ b/PINCache/PINApplicationBackgroundTask.m
@@ -37,10 +37,12 @@
 {
   PINApplicationBackgroundTask *task = [[self alloc] init];
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+  // We have to declare this reference outside of the block, otherwise, the compiler complains about using [UIApplication sharedApplication] in a context that might be available from an extension
+  UIApplication *sharedApplication = [UIApplication sharedApplication];
   task.taskID = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
     UIBackgroundTaskIdentifier taskID = task.taskID;
     task.taskID = UIBackgroundTaskInvalid;
-    [[UIApplication sharedApplication] endBackgroundTask:taskID];
+    [sharedApplication endBackgroundTask:taskID];
   }];
 #endif
   return task;

--- a/PINCache/PINApplicationBackgroundTask.m
+++ b/PINCache/PINApplicationBackgroundTask.m
@@ -6,7 +6,6 @@
 //  Copyright © 2016 Pinterest. All rights reserved.
 //
 
-#if !TARGET_OS_WATCH
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
 #import <UIKit/UIKit.h>
 #endif
@@ -15,7 +14,7 @@
 
 @interface PINApplicationBackgroundTask ()
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !TARGET_OS_WATCH
 @property (atomic, assign) UIBackgroundTaskIdentifier taskID;
 #endif
 
@@ -26,7 +25,7 @@
 - (instancetype)init
 {
   if (self = [super init]) {
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !TARGET_OS_WATCH
     _taskID = UIBackgroundTaskInvalid;
 #endif
   }
@@ -36,7 +35,7 @@
 + (instancetype)start
 {
   PINApplicationBackgroundTask *task = [[self alloc] init];
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !TARGET_OS_WATCH
   // We have to declare this reference outside of the block, otherwise, the compiler complains about using [UIApplication sharedApplication] in a context that might be available from an extension
   UIApplication *sharedApplication = [UIApplication sharedApplication];
   task.taskID = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
@@ -50,7 +49,7 @@
 
 - (void)end
 {
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !TARGET_OS_WATCH
   UIBackgroundTaskIdentifier taskID = self.taskID;
   self.taskID = UIBackgroundTaskInvalid;
   [[UIApplication sharedApplication] endBackgroundTask:taskID];
@@ -58,4 +57,3 @@
 }
 
 @end
-#endif

--- a/PINCache/PINApplicationBackgroundTask.m
+++ b/PINCache/PINApplicationBackgroundTask.m
@@ -1,0 +1,59 @@
+//
+//  PINApplicationBackgroundTask.m
+//  PINCache
+//
+//  Created by Ben Asher on 2/11/16.
+//  Copyright © 2016 Pinterest. All rights reserved.
+//
+
+#if !TARGET_OS_WATCH
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+#import <UIKit/UIKit.h>
+#endif
+
+#import "PINApplicationBackgroundTask.h"
+
+@interface PINApplicationBackgroundTask ()
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+@property (atomic, assign) UIBackgroundTaskIdentifier taskID;
+#endif
+
+@end
+
+@implementation PINApplicationBackgroundTask
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+    _taskID = UIBackgroundTaskInvalid;
+#endif
+  }
+  return self;
+}
+
++ (instancetype)start
+{
+  PINApplicationBackgroundTask *task = [[self alloc] init];
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+  task.taskID = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+    UIBackgroundTaskIdentifier taskID = task.taskID;
+    task.taskID = UIBackgroundTaskInvalid;
+    [[UIApplication sharedApplication] endBackgroundTask:taskID];
+  }];
+#endif
+  return task;
+}
+
+- (void)end
+{
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+  UIBackgroundTaskIdentifier taskID = self.taskID;
+  self.taskID = UIBackgroundTaskInvalid;
+  [[UIApplication sharedApplication] endBackgroundTask:taskID];
+#endif
+}
+
+@end
+#endif

--- a/PINCache/PINBackgroundTask.h
+++ b/PINCache/PINBackgroundTask.h
@@ -1,0 +1,21 @@
+//
+//  PINBackgroundTask.h
+//  PINCache
+//
+//  Created by Ben Asher on 2/11/16.
+//  Copyright © 2016 Pinterest. All rights reserved.
+//
+
+//! Protocol to abstract background tasks across different platforms
+@protocol PINBackgroundTask <NSObject>
+
+/**
+ Starts and returns a new background task instance.
+ */
++ (instancetype)start;
+/**
+ Ends the in-progress background task.
+ */
+- (void)end;
+
+@end

--- a/PINCache/PINCache.h
+++ b/PINCache/PINCache.h
@@ -77,7 +77,15 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  
  @result The shared singleton cache instance.
  */
-+ (instancetype)sharedCache;
++ (instancetype)sharedCache NS_EXTENSION_UNAVAILABLE_IOS("Use sharedCacheForExtensions instead.");
+
+/**
+ A shared cache.
+ 
+ @result The shared singleton cache instance.
+ @note Uses a shared PINDiskCache that is created using an extension-safe initializer
+ */
++ (instancetype)sharedCacheForExtensions;
 
 - (instancetype)init NS_UNAVAILABLE;
 
@@ -89,7 +97,19 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  @param name The name of the cache.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(NSString *)name;
+- (instancetype)initWithName:(NSString *)name NS_EXTENSION_UNAVAILABLE_IOS("Use initForExtensionsWithName:rootPath: instead.");
+
+/**
+ Multiple instances with the same name are allowed and can safely access
+ the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
+ 
+ @see name
+ @param name The name of the cache.
+ @param rootPath The path of the cache on disk.
+ @result A new cache with the specified name.
+ @note By default, PINDiskCache will create UIApplication background tasks during critical operations. This behavior is not available in extensions
+ */
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath NS_EXTENSION_UNAVAILABLE_IOS("Use initForExtensionsWithName:rootPath: instead.") NS_DESIGNATED_INITIALIZER;
 
 /**
  Multiple instances with the same name are allowed and can safely access
@@ -100,21 +120,7 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  @param rootPath The path of the cache on disk.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath NS_DESIGNATED_INITIALIZER;
-
-#if !TARGET_OS_WATCH
-/**
- Multiple instances with the same name are allowed and can safely access
- the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
- 
- @see name
- @param name The name of the cache.
- @param rootPath The path of the cache on disk.
- @result A new cache with the specified name.
- @note This method initializes the receiver's internal PINDiskCache using intiWithBackgroundTasksWithName:rootPath:. See the PINDiskCache initializer for more info.
- */
-- (instancetype)initWithBackgroundTasksWithName:(NSString *)name rootPath:(NSString *)rootPath NS_DESIGNATED_INITIALIZER NS_EXTENSION_UNAVAILABLE_IOS("Use initWithName:rootPath: instead.");
-#endif
+- (instancetype)initForExtensionsWithName:(NSString *)name rootPath:(NSString *)rootPath NS_DESIGNATED_INITIALIZER;
 
 #pragma mark -
 /// @name Asynchronous Methods

--- a/PINCache/PINCache.h
+++ b/PINCache/PINCache.h
@@ -37,7 +37,6 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  The parallel caches are accessible as public properties (<memoryCache> and <diskCache>) and can be manipulated
  separately if necessary. See the docs for <PINMemoryCache> and <PINDiskCache> for more details.
 
- @warning when using in extension or watch extension, define PIN_APP_EXTENSIONS=1
  */
 
 @interface PINCache : NSObject
@@ -102,6 +101,20 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  @result A new cache with the specified name.
  */
 - (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath NS_DESIGNATED_INITIALIZER;
+
+#if !TARGET_OS_WATCH
+/**
+ Multiple instances with the same name are allowed and can safely access
+ the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
+ 
+ @see name
+ @param name The name of the cache.
+ @param rootPath The path of the cache on disk.
+ @result A new cache with the specified name.
+ @note This method initializes the receiver's internal PINDiskCache using intiWithBackgroundTasksWithName:rootPath:. See the PINDiskCache initializer for more info.
+ */
+- (instancetype)initWithBackgroundTasksWithName:(NSString *)name rootPath:(NSString *)rootPath NS_DESIGNATED_INITIALIZER NS_EXTENSION_UNAVAILABLE_IOS("Use initWithName:rootPath: instead.");
+#endif
 
 #pragma mark -
 /// @name Asynchronous Methods

--- a/PINCache/PINCache.m
+++ b/PINCache/PINCache.m
@@ -89,7 +89,8 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     return cache;
 }
 
-+ (instancetype)sharedCacheForExtensions {
++ (instancetype)sharedCacheForExtensions
+{
     static id cache;
     static dispatch_once_t predicate;
     

--- a/PINCache/PINCache.m
+++ b/PINCache/PINCache.m
@@ -55,8 +55,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     return self;
 }
 
-#if !TARGET_OS_WATCH
-- (instancetype)initWithBackgroundTasksWithName:(NSString *)name rootPath:(NSString *)rootPath
+- (instancetype)initForExtensionsWithName:(NSString *)name rootPath:(NSString *)rootPath
 {
     if (!name) {
         return nil;
@@ -67,12 +66,11 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
         NSString *queueName = [[NSString alloc] initWithFormat:@"%@.%p", PINCachePrefix, self];
         _concurrentQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@ Asynchronous Queue", queueName] UTF8String], DISPATCH_QUEUE_CONCURRENT);
 
-        _diskCache = [[PINDiskCache alloc] initWithBackgroundTasksWithName:_name rootPath:rootPath];
+        _diskCache = [[PINDiskCache alloc] initForExtensionsWithName:_name rootPath:rootPath];
         _memoryCache = [[PINMemoryCache alloc] init];
     }
     return self;
 }
-#endif
 
 - (NSString *)description
 {
@@ -86,6 +84,17 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     
     dispatch_once(&predicate, ^{
         cache = [[self alloc] initWithName:PINCacheSharedName];
+    });
+    
+    return cache;
+}
+
++ (instancetype)sharedCacheForExtensions {
+    static id cache;
+    static dispatch_once_t predicate;
+    
+    dispatch_once(&predicate, ^{
+        cache = [[self alloc] initForExtensionsWithName:PINCacheSharedName rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject]];
     });
     
     return cache;

--- a/PINCache/PINCache.m
+++ b/PINCache/PINCache.m
@@ -55,6 +55,25 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     return self;
 }
 
+#if !TARGET_OS_WATCH
+- (instancetype)initWithBackgroundTasksWithName:(NSString *)name rootPath:(NSString *)rootPath
+{
+  if (!name)
+    return nil;
+  
+  if (self = [super init]) {
+    _name = [name copy];
+    
+    NSString *queueName = [[NSString alloc] initWithFormat:@"%@.%p", PINCachePrefix, self];
+    _concurrentQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@ Asynchronous Queue", queueName] UTF8String], DISPATCH_QUEUE_CONCURRENT);
+    
+    _diskCache = [[PINDiskCache alloc] initWithBackgroundTasksWithName:_name rootPath:rootPath];
+    _memoryCache = [[PINMemoryCache alloc] init];
+  }
+  return self;
+}
+#endif
+
 - (NSString *)description
 {
     return [[NSString alloc] initWithFormat:@"%@.%@.%p", PINCachePrefix, _name, self];

--- a/PINCache/PINCache.m
+++ b/PINCache/PINCache.m
@@ -58,19 +58,19 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 #if !TARGET_OS_WATCH
 - (instancetype)initWithBackgroundTasksWithName:(NSString *)name rootPath:(NSString *)rootPath
 {
-  if (!name)
-    return nil;
-  
-  if (self = [super init]) {
-    _name = [name copy];
-    
-    NSString *queueName = [[NSString alloc] initWithFormat:@"%@.%p", PINCachePrefix, self];
-    _concurrentQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@ Asynchronous Queue", queueName] UTF8String], DISPATCH_QUEUE_CONCURRENT);
-    
-    _diskCache = [[PINDiskCache alloc] initWithBackgroundTasksWithName:_name rootPath:rootPath];
-    _memoryCache = [[PINMemoryCache alloc] init];
-  }
-  return self;
+    if (!name) {
+        return nil;
+    }
+    if (self = [super init]) {
+        _name = [name copy];
+
+        NSString *queueName = [[NSString alloc] initWithFormat:@"%@.%p", PINCachePrefix, self];
+        _concurrentQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@ Asynchronous Queue", queueName] UTF8String], DISPATCH_QUEUE_CONCURRENT);
+
+        _diskCache = [[PINDiskCache alloc] initWithBackgroundTasksWithName:_name rootPath:rootPath];
+        _memoryCache = [[PINMemoryCache alloc] init];
+    }
+    return self;
 }
 #endif
 

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -150,12 +150,27 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  
  @result The shared singleton cache instance.
  */
-+ (instancetype)sharedCache;
++ (instancetype)sharedCache NS_EXTENSION_UNAVAILABLE_IOS("Use sharedCacheForExtensions instead.");
+
+/**
+ A shared cache.
+ 
+ @result The shared singleton cache instance.
+ @note Uses a shared PINDiskCache that is created using an extension-safe initializer
+ */
++ (instancetype)sharedCacheForExtensions;
 
 /**
  Empties the trash with `DISPATCH_QUEUE_PRIORITY_BACKGROUND`. Does not use lock.
+ @note This method creates a UIApplication background task while emptying the trash, so it is not available in extensions
  */
-+ (void)emptyTrash;
++ (void)emptyTrash NS_EXTENSION_UNAVAILABLE_IOS("Use emptyTrashWithCompletion: instead.");
+
+/**
+ Empties the trash with `DISPATCH_QUEUE_PRIORITY_BACKGROUND`. Does not use lock.
+ @param completion block called when emptying the trash is complete, which is called on a background queue.
+ */
++ (void)emptyTrashWithCompletion:(nullable void (^)(void))completion;
 
 - (instancetype)init NS_UNAVAILABLE;
 
@@ -167,9 +182,8 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param name The name of the cache.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(NSString *)name;
+- (instancetype)initWithName:(NSString *)name NS_EXTENSION_UNAVAILABLE_IOS("Use initForExtensionWithName:rootPath: instead.");
 
-#if !TARGET_OS_WATCH
 /**
  Multiple instances with the same name are allowed and can safely access
  the same data on disk thanks to the magic of seriality.
@@ -178,10 +192,9 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param name The name of the cache.
  @param rootPath The path of the cache.
  @result A new cache with the specified name.
- @note Using this initializer will cause the disk cache to create UIApplication background tasks during critical operations. This behavior is not available in extensions or watchOS
+ @note By default, the receiver will create UIApplication background tasks during critical operations. This behavior is not available in extensions
  */
-- (instancetype)initWithBackgroundTasksWithName:(NSString *)name rootPath:(NSString *)rootPath NS_DESIGNATED_INITIALIZER NS_EXTENSION_UNAVAILABLE_IOS("Use initWithName:rootPath: instead.");
-#endif
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath NS_EXTENSION_UNAVAILABLE_IOS("Use initWithName:rootPath: instead.") NS_DESIGNATED_INITIALIZER;
 
 /**
  Multiple instances with the same name are allowed and can safely access
@@ -192,7 +205,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param rootPath The path of the cache.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath NS_DESIGNATED_INITIALIZER;
+- (instancetype)initForExtensionsWithName:(NSString *)name rootPath:(NSString *)rootPath NS_DESIGNATED_INITIALIZER;
 
 #pragma mark -
 /// @name Asynchronous Methods

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -169,8 +169,22 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  */
 - (instancetype)initWithName:(NSString *)name;
 
+#if !TARGET_OS_WATCH
 /**
- The designated initializer. Multiple instances with the same name are allowed and can safely access
+ Multiple instances with the same name are allowed and can safely access
+ the same data on disk thanks to the magic of seriality.
+ 
+ @see name
+ @param name The name of the cache.
+ @param rootPath The path of the cache.
+ @result A new cache with the specified name.
+ @note Using this initializer will cause the disk cache to create UIApplication background tasks during critical operations. This behavior is not available in extensions or watchOS
+ */
+- (instancetype)initWithBackgroundTasksWithName:(NSString *)name rootPath:(NSString *)rootPath NS_DESIGNATED_INITIALIZER NS_EXTENSION_UNAVAILABLE_IOS("Use initWithName:rootPath: instead.");
+#endif
+
+/**
+ Multiple instances with the same name are allowed and can safely access
  the same data on disk thanks to the magic of seriality.
  
  @see name

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -182,7 +182,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param name The name of the cache.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(NSString *)name NS_EXTENSION_UNAVAILABLE_IOS("Use initForExtensionWithName:rootPath: instead.");
+- (instancetype)initWithName:(NSString *)name NS_EXTENSION_UNAVAILABLE_IOS("Use initForExtensionsWithName:rootPath: instead.");
 
 /**
  Multiple instances with the same name are allowed and can safely access
@@ -194,7 +194,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @result A new cache with the specified name.
  @note By default, the receiver will create UIApplication background tasks during critical operations. This behavior is not available in extensions
  */
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath NS_EXTENSION_UNAVAILABLE_IOS("Use initWithName:rootPath: instead.") NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath NS_EXTENSION_UNAVAILABLE_IOS("Use initForExtensionsWithName:rootPath: instead.") NS_DESIGNATED_INITIALIZER;
 
 /**
  Multiple instances with the same name are allowed and can safely access

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -67,7 +67,8 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     return [self initWithName:name rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex:0]];
 }
 
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath {
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath
+{
     if (!name) {
         return nil;
     }
@@ -78,7 +79,8 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     return self;
 }
 
-- (instancetype)initForExtensionsWithName:(NSString *)name rootPath:(NSString *)rootPath {
+- (instancetype)initForExtensionsWithName:(NSString *)name rootPath:(NSString *)rootPath
+{
     if (!name) {
       return nil;
     }
@@ -106,7 +108,8 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     return cache;
 }
 
-+ (instancetype)sharedCacheForExtensions {
++ (instancetype)sharedCacheForExtensions
+{
     static id cache;
     static dispatch_once_t predicate;
     
@@ -119,12 +122,14 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
 
 #pragma mark - Private Methods -
 
-- (id<PINBackgroundTask>)startBackgroundTask {
+- (id<PINBackgroundTask>)startBackgroundTask
+{
   return [self.backgroundTaskClass start];
 }
 
 //! This method should only be called from an initializer
-- (void)prepareCacheWithName:(NSString *)name rootPath:(NSString *)rootPath {
+- (void)prepareCacheWithName:(NSString *)name rootPath:(NSString *)rootPath
+{
     _name = [name copy];
     _asyncQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@ Asynchronous Queue", PINDiskCachePrefix] UTF8String], DISPATCH_QUEUE_CONCURRENT);
     _lockSemaphore = dispatch_semaphore_create(1);
@@ -277,23 +282,23 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
 
 + (void)emptyTrashWithCompletion:(void (^)(void))completion
 {
-  dispatch_async([self sharedTrashQueue], ^{
-    NSError *searchTrashedItemsError = nil;
-    NSArray *trashedItems = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:[self sharedTrashURL]
-                                                          includingPropertiesForKeys:nil
-                                                                             options:0
-                                                                               error:&searchTrashedItemsError];
-    PINDiskCacheError(searchTrashedItemsError);
-    
-    for (NSURL *trashedItemURL in trashedItems) {
-      NSError *removeTrashedItemError = nil;
-      [[NSFileManager defaultManager] removeItemAtURL:trashedItemURL error:&removeTrashedItemError];
-      PINDiskCacheError(removeTrashedItemError);
-    }
-    if (completion) {
-        completion();
-    }
-  });
+    dispatch_async([self sharedTrashQueue], ^{
+        NSError *searchTrashedItemsError = nil;
+        NSArray *trashedItems = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:[self sharedTrashURL]
+                                                              includingPropertiesForKeys:nil
+                                                                                 options:0
+                                                                                   error:&searchTrashedItemsError];
+        PINDiskCacheError(searchTrashedItemsError);
+
+        for (NSURL *trashedItemURL in trashedItems) {
+            NSError *removeTrashedItemError = nil;
+            [[NSFileManager defaultManager] removeItemAtURL:trashedItemURL error:&removeTrashedItemError];
+            PINDiskCacheError(removeTrashedItemError);
+        }
+        if (completion) {
+            completion();
+        }
+    });
 }
 
 #pragma mark - Private Queue Methods -
@@ -1110,7 +1115,8 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     });
 }
 
-- (BOOL)isTTLCache {
+- (BOOL)isTTLCache
+{
     BOOL isTTLCache;
     
     [self lock];
@@ -1120,7 +1126,8 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
     return isTTLCache;
 }
 
-- (void)setTtlCache:(BOOL)ttlCache {
+- (void)setTtlCache:(BOOL)ttlCache
+{
     __weak PINDiskCache *weakSelf = self;
 
     dispatch_async(_asyncQueue, ^{

--- a/PINCache/PINMemoryCache.m
+++ b/PINCache/PINMemoryCache.m
@@ -115,7 +115,6 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 
     __weak PINMemoryCache *weakSelf = self;
 
->>>>>>> Attempt at removing need for PIN_APP_EXTENSIONS
     dispatch_async(_concurrentQueue, ^{
         PINMemoryCache *strongSelf = weakSelf;
         if (!strongSelf) {

--- a/PINCache/PINMemoryCache.m
+++ b/PINCache/PINMemoryCache.m
@@ -109,7 +109,8 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 
 #pragma mark - Private Methods -
 
-- (void)didReceiveMemoryWarningNotification:(NSNotification *)notification {
+- (void)didReceiveMemoryWarningNotification:(NSNotification *)notification
+{
     if (self.removeAllObjectsOnMemoryWarning)
         [self removeAllObjects:nil];
 
@@ -686,7 +687,8 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     return cost;
 }
 
-- (BOOL)isTTLCache {
+- (BOOL)isTTLCache
+{
     BOOL isTTLCache;
     
     [self lock];
@@ -696,7 +698,8 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     return isTTLCache;
 }
 
-- (void)setTtlCache:(BOOL)ttlCache {
+- (void)setTtlCache:(BOOL)ttlCache
+{
     [self lock];
         _ttlCache = ttlCache;
     [self unlock];

--- a/PINCache/PINMemoryCache.m
+++ b/PINCache/PINMemoryCache.m
@@ -115,6 +115,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 
     __weak PINMemoryCache *weakSelf = self;
 
+>>>>>>> Attempt at removing need for PIN_APP_EXTENSIONS
     dispatch_async(_concurrentQueue, ^{
         PINMemoryCache *strongSelf = weakSelf;
         if (!strongSelf) {

--- a/docs/com.pinterest.PINCache-2.0.docset/Contents/Resources/Documents/Classes/PINCache.html
+++ b/docs/com.pinterest.PINCache-2.0.docset/Contents/Resources/Documents/Classes/PINCache.html
@@ -149,7 +149,7 @@ repopulated in memory the next time they are accessed. <code>PINCache</code> als
 dispatch group to wait for both caches to finish their operations without blocking each other.</p>
 
 <p>The parallel caches are accessible as public properties (<a href="#//api/name/memoryCache">memoryCache</a> and <a href="#//api/name/diskCache">diskCache</a>) and can be manipulated
-separately if necessary. See the docs for <a href="../Classes/PINMemoryCache.html">PINMemoryCache</a> and <a href="../Classes/PINDiskCache.html">PINDiskCache</a> for more details.</p><div class="warning"><p><strong>Warning:</strong> to use PINCache in an extension or watch app, define PIN_APP_EXTENSIONS=1</p></div>
+separately if necessary. See the docs for <a href="../Classes/PINMemoryCache.html">PINMemoryCache</a> and <a href="../Classes/PINDiskCache.html">PINDiskCache</a> for more details.</p>
 					</div>
 					
 					

--- a/docs/html/Classes/PINCache.html
+++ b/docs/html/Classes/PINCache.html
@@ -149,7 +149,7 @@ repopulated in memory the next time they are accessed. <code>PINCache</code> als
 dispatch group to wait for both caches to finish their operations without blocking each other.</p>
 
 <p>The parallel caches are accessible as public properties (<a href="#//api/name/memoryCache">memoryCache</a> and <a href="#//api/name/diskCache">diskCache</a>) and can be manipulated
-separately if necessary. See the docs for <a href="../Classes/PINMemoryCache.html">PINMemoryCache</a> and <a href="../Classes/PINDiskCache.html">PINDiskCache</a> for more details.</p><div class="warning"><p><strong>Warning:</strong> to use PINCache in an extension or watch app, define PIN_APP_EXTENSIONS=1</p></div>
+separately if necessary. See the docs for <a href="../Classes/PINMemoryCache.html">PINMemoryCache</a> and <a href="../Classes/PINDiskCache.html">PINDiskCache</a> for more details.</p>
 					</div>
 					
 					

--- a/tests/PINCache.xcodeproj/project.pbxproj
+++ b/tests/PINCache.xcodeproj/project.pbxproj
@@ -19,6 +19,10 @@
 		662900461A66B830009C10BD /* PINMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = D0E5D83E171DF0AF0041E777 /* PINMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		662900471A66B831009C10BD /* PINDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = D0E5D83C171DF0AF0041E777 /* PINDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		662900481A66B831009C10BD /* PINMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = D0E5D83E171DF0AF0041E777 /* PINMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A82D9ACD1C6D0D81007680F8 /* PINApplicationBackgroundTask.m in Sources */ = {isa = PBXBuildFile; fileRef = A82D9ACC1C6D0D81007680F8 /* PINApplicationBackgroundTask.m */; };
+		A82D9ACF1C6D0DA1007680F8 /* PINApplicationBackgroundTask.m in Sources */ = {isa = PBXBuildFile; fileRef = A82D9ACC1C6D0D81007680F8 /* PINApplicationBackgroundTask.m */; };
+		A82D9AD01C6D0DA1007680F8 /* PINApplicationBackgroundTask.m in Sources */ = {isa = PBXBuildFile; fileRef = A82D9ACC1C6D0D81007680F8 /* PINApplicationBackgroundTask.m */; };
+		A82D9AD11C6D0DA2007680F8 /* PINApplicationBackgroundTask.m in Sources */ = {isa = PBXBuildFile; fileRef = A82D9ACC1C6D0D81007680F8 /* PINApplicationBackgroundTask.m */; };
 		D07F1EB6171AFB7A001DBA02 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D07F1EB5171AFB7A001DBA02 /* UIKit.framework */; };
 		D07F1EB8171AFB7A001DBA02 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D07F1EB7171AFB7A001DBA02 /* Foundation.framework */; };
 		D07F1EBA171AFB7A001DBA02 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D07F1EB9171AFB7A001DBA02 /* CoreGraphics.framework */; };
@@ -67,6 +71,9 @@
 		662900141A66B60D009C10BD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6629FFED1A66B512009C10BD /* PINCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PINCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6629FFF01A66B512009C10BD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A82D9ACB1C6D0D81007680F8 /* PINApplicationBackgroundTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PINApplicationBackgroundTask.h; sourceTree = "<group>"; };
+		A82D9ACC1C6D0D81007680F8 /* PINApplicationBackgroundTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PINApplicationBackgroundTask.m; sourceTree = "<group>"; };
+		A82D9ACE1C6D0D95007680F8 /* PINBackgroundTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINBackgroundTask.h; sourceTree = "<group>"; };
 		D07F1EB2171AFB7A001DBA02 /* PINCache.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PINCache.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D07F1EB5171AFB7A001DBA02 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		D07F1EB7171AFB7A001DBA02 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -239,6 +246,9 @@
 				D0E5D83D171DF0AF0041E777 /* PINDiskCache.m */,
 				D0E5D83E171DF0AF0041E777 /* PINMemoryCache.h */,
 				D0E5D83F171DF0AF0041E777 /* PINMemoryCache.m */,
+				A82D9ACE1C6D0D95007680F8 /* PINBackgroundTask.h */,
+				A82D9ACB1C6D0D81007680F8 /* PINApplicationBackgroundTask.h */,
+				A82D9ACC1C6D0D81007680F8 /* PINApplicationBackgroundTask.m */,
 			);
 			name = PINCache;
 			path = ../PINCache;
@@ -423,6 +433,7 @@
 				662900401A66B79B009C10BD /* PINCache.m in Sources */,
 				662900411A66B79B009C10BD /* PINDiskCache.m in Sources */,
 				662900421A66B79B009C10BD /* PINMemoryCache.m in Sources */,
+				A82D9AD11C6D0DA2007680F8 /* PINApplicationBackgroundTask.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -433,6 +444,7 @@
 				6629003B1A66B76B009C10BD /* PINCache.m in Sources */,
 				6629003C1A66B76B009C10BD /* PINDiskCache.m in Sources */,
 				6629003D1A66B76B009C10BD /* PINMemoryCache.m in Sources */,
+				A82D9AD01C6D0DA1007680F8 /* PINApplicationBackgroundTask.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -441,6 +453,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D07F1EC2171AFB7A001DBA02 /* main.m in Sources */,
+				A82D9ACD1C6D0D81007680F8 /* PINApplicationBackgroundTask.m in Sources */,
 				D07F1EC6171AFB7A001DBA02 /* PINAppDelegate.m in Sources */,
 				D0E5D840171DF0AF0041E777 /* PINCache.m in Sources */,
 				D0E5D842171DF0AF0041E777 /* PINDiskCache.m in Sources */,
@@ -453,6 +466,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A82D9ACF1C6D0DA1007680F8 /* PINApplicationBackgroundTask.m in Sources */,
 				D07F1EE1171AFB7A001DBA02 /* PINCacheTests.m in Sources */,
 				D0E5D841171DF0AF0041E777 /* PINCache.m in Sources */,
 				D0E5D843171DF0AF0041E777 /* PINDiskCache.m in Sources */,

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -527,7 +527,8 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     XCTAssert(diskObj == nil, @"should not be in disk cache");
 }
 
-- (void)testTTLCacheObjectAccess {
+- (void)testTTLCacheObjectAccess
+{
     [self.cache removeAllObjects];
     NSString *key = @"key";
     [self.cache.memoryCache setAgeLimit:2];
@@ -591,7 +592,8 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     XCTAssertNotNil(diskObj, @"should still be in disk cache");
 }
 
-- (void)testTTLCacheObjectEnumeration {
+- (void)testTTLCacheObjectEnumeration
+{
     [self.cache removeAllObjects];
     NSString *key = @"key";
     [self.cache.memoryCache setAgeLimit:2];
@@ -659,7 +661,8 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", (unsigned long)expectedObjCount);
 }
 
-- (void)testTTLCacheFileURLForKey {
+- (void)testTTLCacheFileURLForKey
+{
     NSString *key = @"key";
 
     dispatch_group_t group = dispatch_group_create();


### PR DESCRIPTION
This PR is might still be a bit rough around the edges, but everything now pod lib lints, and it also works in an extension without having to compile out the UIApplication background task bits. I could however get the ```__WATCHOS_UNAVAILABLE``` macro to work in the same way, so I just decided to screw that and compile ```TARGET_OS_WATCH``` incompatible bits out of the code.