### PR TITLE
Fixed fileURLForKey: updating the file modification date, when TTLCache is enabled

### DIFF
--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -663,7 +663,10 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
         fileURL = [self encodedFileURLForKey:key];
         
         if ([[NSFileManager defaultManager] fileExistsAtPath:[fileURL path]]) {
-            [self setFileModificationDate:now forURL:fileURL];
+            // Don't update the file modification time, if self is a ttlCache
+            if (!self->_ttlCache) {
+                [self setFileModificationDate:now forURL:fileURL];
+            }
         } else {
             fileURL = nil;
         }

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -611,8 +611,8 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     // Wait for ttlCache to be set
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
-    [self.cache objectForKey:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
-      dispatch_group_leave(group);
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL * _Nullable fileURL) {
+        dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
 
@@ -637,8 +637,8 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
 
     // Wait for ttlCache to be set
     dispatch_group_enter(group);
-    [self.cache objectForKey:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
-      dispatch_group_leave(group);
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL * _Nullable fileURL) {
+        dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
 
@@ -683,7 +683,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     [self.cache.diskCache setTtlCache:YES];
     // Wait for ttlCache to be set
     dispatch_group_enter(group);
-    [self.cache objectForKey:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL * _Nullable fileURL) {
       dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
@@ -699,7 +699,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     [self.cache.diskCache setTtlCache:NO];
     // Wait for ttlCache to be set
     dispatch_group_enter(group);
-    [self.cache objectForKey:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL * _Nullable fileURL) {
       dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);


### PR DESCRIPTION
This is a minor bug we found when doing some more testing with the ttlCache behavior enabled. I missed that fileURLForKey: could also update PINDiskCache's file modification time. This fixes that.