### PR TITLE
We were seeing strange, long running dladdr lookups deep in backgound…

### DIFF
--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -243,9 +243,9 @@ static NSString * const PINDiskCacheSharedName = @"PINDiskCacheShared";
 
 + (void)emptyTrash
 {
-    PINBackgroundTask *task = [PINBackgroundTask start];
-    
     dispatch_async([self sharedTrashQueue], ^{
+        PINBackgroundTask *task = [PINBackgroundTask start];
+        
         NSError *searchTrashedItemsError = nil;
         NSArray *trashedItems = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:[self sharedTrashURL]
                                                               includingPropertiesForKeys:nil


### PR DESCRIPTION
… task start on the main thread, specifically when emptying trash. No reason to not start the background task after dispatching.