### PR TITLE
Nullability correction

### DIFF
--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -311,7 +311,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param key The key associated with the object.
  @result The file URL for the specified key.
  */
-- (NSURL *)fileURLForKey:(nullable NSString *)key;
+- (nullable NSURL *)fileURLForKey:(nullable NSString *)key;
 
 /**
  Stores an object in the cache for the specified key. This method blocks the calling thread until

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -68,7 +68,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  The total number of bytes used on disk, as reported by `NSURLTotalFileAllocatedSizeKey`.
  
  @warning This property should only be read from a call to <synchronouslyLockFileAccessWhileExecutingBlock:> or
- its asynchronous equivolent <lockFileAccessWhileExecutingBlock:>
+ its asynchronous equivalent <lockFileAccessWhileExecutingBlock:>
  
  For example:
  

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -171,7 +171,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
 
     dispatch_semaphore_wait(semaphore, [self timeout]);
     
-    XCTAssertNil(image, @"object with non-existant key was not nil");
+    XCTAssertNil(image, @"object with non-existent key was not nil");
 }
 
 - (void)testObjectRemove
@@ -534,7 +534,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     [self.cache.diskCache setAgeLimit:2];
 
 
-    // The cache is going to clear at 2 seconds, set an object at 1 second, so that it misses the first cach clearing
+    // The cache is going to clear at 2 seconds, set an object at 1 second, so that it misses the first cache clearing
     sleep(1);
     [self.cache setObject:[self image] forKey:key];
 
@@ -598,7 +598,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 5.0;
     [self.cache.diskCache setAgeLimit:2];
 
 
-    // The cache is going to clear at 2 seconds, set an object at 1 second, so that it misses the first cach clearing
+    // The cache is going to clear at 2 seconds, set an object at 1 second, so that it misses the first cache clearing
     sleep(1);
     [self.cache setObject:[self image] forKey:key];
 


### PR DESCRIPTION
PINDiskCache's `fileURLForKey:` returns nil whenever the cache does not hold the object for the specified key.