### PR TITLE
Add fileURL back into `PINDiskCacheObjectBlock` and allow custom file extension

### DIFF
--- a/PINCache/PINCache.m
+++ b/PINCache/PINCache.m
@@ -122,7 +122,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
                         block(strongSelf, memoryCacheKey, memoryCacheObject);
                 });
             } else {
-                [strongSelf->_diskCache objectForKey:memoryCacheKey block:^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> diskCacheObject) {
+                [strongSelf->_diskCache objectForKey:memoryCacheKey block:^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> diskCacheObject, NSURL *fileURL) {
                     PINCache *strongSelf = weakSelf;
                     if (!strongSelf)
                         return;
@@ -161,7 +161,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
             dispatch_group_leave(group);
         };
         
-        diskBlock = ^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> memoryCacheObject) {
+        diskBlock = ^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> memoryCacheObject, NSURL *fileURL) {
             dispatch_group_leave(group);
         };
     }
@@ -201,7 +201,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
             dispatch_group_leave(group);
         };
         
-        diskBlock = ^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> memoryCacheObject) {
+        diskBlock = ^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> memoryCacheObject, NSURL *fileURL) {
             dispatch_group_leave(group);
         };
     }

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -19,7 +19,7 @@ typedef void (^PINDiskCacheBlock)(PINDiskCache *cache);
 /**
  A callback block which provides the cache, key and object as arguments
  */
-typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding>  __nullable object);
+typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding>  __nullable object, NSURL * __nullable fileURL);
 
 /**
  A callback block which provides the key and fileURL of the object

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -126,6 +126,10 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data);
  */
 @property (assign) NSTimeInterval ageLimit;
 
+/**
+ Extension for all cache files on disk. Defaults to no extension. 
+ */
+@property (nonatomic, nullable, copy) NSString *fileExtension;
 
 /**
  The writing protection option used when writing a file on disk. This value is used every time an object is set.

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -187,7 +187,13 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
     }
     
     if ([string respondsToSelector:@selector(stringByAddingPercentEncodingWithAllowedCharacters:)]) {
-        return [string stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@".:/%"] invertedSet]];
+        NSString *encodedString = [string stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@".:/%"] invertedSet]];
+        if (self.fileExtension) {
+            return [encodedString stringByAppendingPathExtension:self.fileExtension];
+        }
+        else {
+            return encodedString;
+        }
     }
     else {
         CFStringRef static const charsToEscape = CFSTR(".:/%");
@@ -199,8 +205,15 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
                                                                             charsToEscape,
                                                                             kCFStringEncodingUTF8);
 #pragma clang diagnostic pop
-        return (__bridge_transfer NSString *)escapedString;
+        
+        if (self.fileExtension) {
+            return [(__bridge_transfer NSString *)escapedString stringByAppendingPathExtension:self.fileExtension];
+        }
+        else {
+            return (__bridge_transfer NSString *)escapedString;
+        }
     }
+    
 }
 
 - (NSString *)decodedString:(NSString *)string

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -392,7 +392,7 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         PINDiskCacheObjectBlock willRemoveObjectBlock = _willRemoveObjectBlock;
         if (willRemoveObjectBlock) {
             [self unlock];
-            willRemoveObjectBlock(self, key, nil);
+            willRemoveObjectBlock(self, key, nil, nil);
             [self lock];
         }
         
@@ -414,7 +414,7 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         PINDiskCacheObjectBlock didRemoveObjectBlock = _didRemoveObjectBlock;
         if (didRemoveObjectBlock) {
             [self unlock];
-            _didRemoveObjectBlock(self, key, nil);
+            _didRemoveObjectBlock(self, key, nil, nil);
             [self lock];
         }
     
@@ -548,7 +548,7 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         id <NSCoding> object = [strongSelf objectForKey:key fileURL:&fileURL];
         
         if (block) {
-            block(strongSelf, key, object);
+            block(strongSelf, key, object, fileURL);
         }
     });
 }
@@ -579,7 +579,7 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         [strongSelf setObject:object forKey:key fileURL:&fileURL];
         
         if (block) {
-            block(strongSelf, key, object);
+            block(strongSelf, key, object, fileURL);
         }
     });
 }
@@ -594,7 +594,7 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         [strongSelf removeObjectForKey:key fileURL:&fileURL];
         
         if (block) {
-            block(strongSelf, key, nil);
+            block(strongSelf, key, nil, nil);
         }
     });
 }
@@ -795,7 +795,7 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         PINDiskCacheObjectBlock willAddObjectBlock = self->_willAddObjectBlock;
         if (willAddObjectBlock) {
             [self unlock];
-            willAddObjectBlock(self, key, object);
+            willAddObjectBlock(self, key, object, fileURL);
             [self lock];
         }
     
@@ -831,7 +831,7 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         PINDiskCacheObjectBlock didAddObjectBlock = self->_didAddObjectBlock;
         if (didAddObjectBlock) {
             [self unlock];
-            didAddObjectBlock(self, key, object);
+            didAddObjectBlock(self, key, object, fileURL);
             [self lock];
         }
     [self unlock];

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -796,4 +796,24 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:[testCacheURL path]]);
 }
 
+- (void)testCustomFileExtension {
+    
+    self.cache.diskCache.fileExtension = @"obj";
+    
+    NSString *key = @"key";
+    __block NSURL *diskFileURL = nil;
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    
+    [self.cache.diskCache setObject:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object, NSURL *fileURL) {
+        diskFileURL = fileURL;
+        dispatch_semaphore_signal(semaphore);
+    }];
+    
+    dispatch_semaphore_wait(semaphore, [self timeout]);
+    
+    XCTAssertNotNil(diskFileURL.pathExtension);
+    XCTAssertEqualObjects(diskFileURL.pathExtension, @"obj");
+    
+}
+
 @end

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -458,7 +458,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
         NSString *key = [[NSString alloc] initWithFormat:@"key %zd", index];
         NSString *obj = [[NSString alloc] initWithFormat:@"obj %zd", index];
         dispatch_group_enter(group);
-        [self.cache.diskCache setObject:obj forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+        [self.cache.diskCache setObject:obj forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object, NSURL *fileURL) {
             dispatch_group_leave(group);
         }];
     });
@@ -526,7 +526,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
     }];
     
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object, NSURL *fileURL) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -548,7 +548,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
     }];
     
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object, NSURL *fileURL) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -576,11 +576,9 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
   __block NSURL *diskFileURL = nil;
   dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-  [self.cache.diskCache setObject:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
-    [cache fileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
-        diskFileURL = fileURL;
-        dispatch_semaphore_signal(semaphore);
-    }];
+  [self.cache.diskCache setObject:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object, NSURL *fileURL) {
+      diskFileURL = fileURL;
+      dispatch_semaphore_signal(semaphore);
   }];
   
   dispatch_semaphore_wait(semaphore, [self timeout]);
@@ -621,7 +619,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
     }];
 
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object, NSURL *fileURL) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -645,7 +643,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
     }];
 
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object, NSURL *fileURL) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -676,7 +674,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
     // Wait for ttlCache to be set
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL *fileURL) {
         dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
@@ -702,7 +700,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
 
     // Wait for ttlCache to be set
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL *fileURL) {
         dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
@@ -730,11 +728,9 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
     __block NSURL *objectURL = nil;
-    [self.cache.diskCache setObject:[self image] forKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
-        [cache fileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
-            objectURL = fileURL;
-            dispatch_group_leave(group);
-        }];
+    [self.cache.diskCache setObject:[self image] forKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL *fileURL) {
+        objectURL = fileURL;
+        dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
     XCTAssertNotNil(objectURL, @"objectURL should have a non-nil URL");
@@ -750,7 +746,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
     [self.cache.diskCache setTtlCache:YES];
     // Wait for ttlCache to be set
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL *fileURL) {
       dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
@@ -766,7 +762,7 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
     [self.cache.diskCache setTtlCache:NO];
     // Wait for ttlCache to be set
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object, NSURL *fileURL) {
       dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);


### PR DESCRIPTION
Hi there,

Firstly, I'd like to say thank you for the work you've put into maintaining PINCache. I've started using this instead of TMDiskCache for storing video clips.

So, this PR consists of two parts:

## Adding the fileURL back into `PINDiskCacheObjectBlock`

I'm not sure what the rationale behind its removal was, but in my use-case it would require an additional call to the cache after adding an object in order to retrieve the fileURL. It seems unnecessary since the fileURL is available at the time of storage.

## Adding an optional file extension

By default, files are stored using an escaped key. If I provide a serialiser / deserialiser that doesn't perform any operation on `NSData` objects, I can feed the file URLs directly into other API, in my case `AVPlayerItem`. Unfortunately, `AVPlayerItem` is particularly strict when it comes to reading file URLs and requires that there be an extension.

I have therefore added a `fileExtension` property to `PINDiskCache` that is used after encoding a key.

I appreciate that you may not wish to merge these commits as they are specific to my use of `NSData` and `AVPlayerItem`, however, I thought I'd give you the opportunity to review them in case they are of use.