### PR TITLE
Add support for a custom file extension

### DIFF
--- a/PINCache/PINCache.h
+++ b/PINCache/PINCache.h
@@ -94,7 +94,18 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param name The name of the cache.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(NSString *)name;
+- (instancetype)initWithName:(nonnull NSString *)name;
+
+/**
+ Multiple instances with the same name are allowed and can safely access
+ the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
+ 
+ @see name
+ @param name The name of the cache.
+ @param fileExtension The file extension for files on disk.
+ @result A new cache with the specified name.
+ */
+- (instancetype)initWithName:(nonnull NSString *)name fileExtension:(nullable NSString *)fileExtension;
 
 /**
  Multiple instances with the same name are allowed and can safely access
@@ -103,9 +114,10 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @see name
  @param name The name of the cache.
  @param rootPath The path of the cache on disk.
+ @param fileExtension The file extension for files on disk.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath;
+- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath fileExtension:(nullable NSString *)fileExtension;
 
 /**
  Multiple instances with the same name are allowed and can safely access
@@ -118,9 +130,10 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param rootPath The path of the cache on disk.
  @param serializer   A block used to serialize object before writing to disk. If nil provided, default NSKeyedArchiver serialized will be used.
  @param deserializer A block used to deserialize object read from disk. If nil provided, default NSKeyedUnarchiver serialized will be used.
+ @param fileExtension The file extension for files on disk.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer fileExtension:(nullable NSString *)fileExtension NS_DESIGNATED_INITIALIZER;
 
 
 #pragma mark -

--- a/PINCache/PINCache.m
+++ b/PINCache/PINCache.m
@@ -35,15 +35,20 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 - (instancetype)initWithName:(NSString *)name
 {
-    return [self initWithName:name rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject]];
+    return [self initWithName:name fileExtension:nil];
 }
 
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath
+- (instancetype)initWithName:(NSString *)name fileExtension:(NSString *)fileExtension
 {
-    return [self initWithName:name rootPath:rootPath serializer:nil deserializer:nil];
+    return [self initWithName:name rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject] fileExtension:fileExtension];
 }
 
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(PINDiskCacheSerializerBlock)serializer deserializer:(PINDiskCacheDeserializerBlock)deserializer
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath fileExtension:(NSString *)fileExtension
+{
+    return [self initWithName:name rootPath:rootPath serializer:nil deserializer:nil fileExtension:fileExtension];
+}
+
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(PINDiskCacheSerializerBlock)serializer deserializer:(PINDiskCacheDeserializerBlock)deserializer fileExtension:(NSString *)fileExtension
 {
     if (!name)
         return nil;
@@ -54,7 +59,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
         NSString *queueName = [[NSString alloc] initWithFormat:@"%@.%p", PINCachePrefix, (void *)self];
         _concurrentQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@ Asynchronous Queue", queueName] UTF8String], DISPATCH_QUEUE_CONCURRENT);
         
-        _diskCache = [[PINDiskCache alloc] initWithName:_name rootPath:rootPath serializer:serializer deserializer:deserializer];
+        _diskCache = [[PINDiskCache alloc] initWithName:_name rootPath:rootPath serializer:serializer deserializer:deserializer fileExtension:fileExtension];
         _memoryCache = [[PINMemoryCache alloc] init];
     }
     return self;

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -129,7 +129,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data);
 /**
  Extension for all cache files on disk. Defaults to no extension. 
  */
-@property (nonatomic, nullable, copy) NSString *fileExtension;
+@property (readonly) NSString *fileExtension;
 
 /**
  The writing protection option used when writing a file on disk. This value is used every time an object is set.
@@ -215,30 +215,43 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data);
  @param name The name of the cache.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(NSString *)name;
+- (instancetype)initWithName:(nonnull NSString *)name;
 
 /**
- The designated initializer. Multiple instances with the same name are allowed and can safely access
+ Multiple instances with the same name are allowed and can safely access
+ the same data on disk thanks to the magic of seriality.
+ 
+ @see name
+ @param name The name of the cache.
+ @param fileExtension The file extension for files on disk.
+ @result A new cache with the specified name.
+ */
+- (instancetype)initWithName:(nonnull NSString *)name fileExtension:(nullable NSString *)fileExtension;
+
+/**
+ Multiple instances with the same name are allowed and can safely access
  the same data on disk thanks to the magic of seriality.
  
  @see name
  @param name The name of the cache.
  @param rootPath The path of the cache.
+ @param fileExtension The file extension for files on disk.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath;
+- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath fileExtension:(nullable NSString *)fileExtension;
 
 /**
- Initializer allowing you to override default NSKeyedArchiver/NSKeyedUnarchiver serialization.
+ The designated initializer allowing you to override default NSKeyedArchiver/NSKeyedUnarchiver serialization.
  
  @see name
  @param name The name of the cache.
  @param rootPath The path of the cache.
  @param serializer   A block used to serialize object. If nil provided, default NSKeyedArchiver serialized will be used.
  @param deserializer A block used to deserialize object. If nil provided, default NSKeyedUnarchiver serialized will be used.
+ @param fileExtension The file extension for files on disk.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer fileExtension:(nullable NSString *)fileExtension NS_DESIGNATED_INITIALIZER;
 
 #pragma mark -
 /// @name Asynchronous Methods

--- a/PINCache/PINDiskCache.h
+++ b/PINCache/PINDiskCache.h
@@ -126,6 +126,10 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data);
  */
 @property (assign) NSTimeInterval ageLimit;
 
+/**
+ Extension for all cache files on disk. Defaults to no extension. 
+ */
+@property (nonatomic, nullable, copy) NSString *fileExtension;
 
 /**
  The writing protection option used when writing a file on disk. This value is used every time an object is set.

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -206,7 +206,7 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
                                                                             kCFStringEncodingUTF8);
 #pragma clang diagnostic pop
         
-        if (self.fileExtension) {
+        if (self.fileExtension.length > 0) {
             return [(__bridge_transfer NSString *)escapedString stringByAppendingPathExtension:self.fileExtension];
         }
         else {

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -74,16 +74,20 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
 
 - (instancetype)initWithName:(NSString *)name
 {
-    return [self initWithName:name rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex:0]];
+    return [self initWithName:name fileExtension:nil];
 }
 
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath
+- (instancetype)initWithName:(NSString *)name fileExtension:(NSString *)fileExtension
 {
-    return [self initWithName:name rootPath:rootPath serializer:nil deserializer:nil];
-
+    return [self initWithName:name rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex:0] fileExtension:fileExtension];
 }
 
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(PINDiskCacheSerializerBlock)serializer deserializer:(PINDiskCacheDeserializerBlock)deserializer
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath fileExtension:(NSString *)fileExtension
+{
+    return [self initWithName:name rootPath:rootPath serializer:nil deserializer:nil fileExtension:fileExtension];
+}
+
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(PINDiskCacheSerializerBlock)serializer deserializer:(PINDiskCacheDeserializerBlock)deserializer fileExtension:(NSString *)fileExtension
 {
     if (!name)
         return nil;
@@ -96,6 +100,7 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
     
     if (self = [super init]) {
         _name = [name copy];
+        _fileExtension = [fileExtension copy];
         _asyncQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@ Asynchronous Queue", PINDiskCachePrefix] UTF8String], DISPATCH_QUEUE_CONCURRENT);
         _instanceLock = [[NSConditionLock alloc] initWithCondition:PINDiskCacheConditionNotReady];
         _willAddObjectBlock = nil;

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -187,7 +187,13 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
     }
     
     if ([string respondsToSelector:@selector(stringByAddingPercentEncodingWithAllowedCharacters:)]) {
-        return [string stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@".:/%"] invertedSet]];
+        NSString *encodedString = [string stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@".:/%"] invertedSet]];
+        if (self.fileExtension) {
+            return [encodedString stringByAppendingPathExtension:self.fileExtension];
+        }
+        else {
+            return encodedString;
+        }
     }
     else {
         CFStringRef static const charsToEscape = CFSTR(".:/%");
@@ -199,7 +205,13 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
                                                                             charsToEscape,
                                                                             kCFStringEncodingUTF8);
 #pragma clang diagnostic pop
-        return (__bridge_transfer NSString *)escapedString;
+        
+        if (self.fileExtension) {
+            return [(__bridge_transfer NSString *)escapedString stringByAppendingPathExtension:self.fileExtension];
+        }
+        else {
+            return (__bridge_transfer NSString *)escapedString;
+        }
     }
 }
 

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -193,7 +193,7 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
     
     if ([string respondsToSelector:@selector(stringByAddingPercentEncodingWithAllowedCharacters:)]) {
         NSString *encodedString = [string stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@".:/%"] invertedSet]];
-        if (self.fileExtension) {
+        if (self.fileExtension.length > 0) {
             return [encodedString stringByAppendingPathExtension:self.fileExtension];
         }
         else {

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -802,15 +802,17 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
 
 - (void)testCustomFileExtension {
     
-    self.cache.diskCache.fileExtension = @"obj";
+    PINCache *cache = [[PINCache alloc] initWithName:[[NSUUID UUID] UUIDString] fileExtension:@"obj"];
     
     NSString *key = @"key";
     __block NSURL *diskFileURL = nil;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     
-    [self.cache.diskCache setObject:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object, NSURL *fileURL) {
-        diskFileURL = fileURL;
-        dispatch_semaphore_signal(semaphore);
+    [cache.diskCache setObject:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+        [cache fileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
+            diskFileURL = fileURL;
+            dispatch_semaphore_signal(semaphore);
+        }];
     }];
     
     dispatch_semaphore_wait(semaphore, [self timeout]);

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -800,4 +800,24 @@ static const NSTimeInterval PINCacheTestBlockTimeout = 10.0;
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:[testCacheURL path]]);
 }
 
+- (void)testCustomFileExtension {
+    
+    self.cache.diskCache.fileExtension = @"obj";
+    
+    NSString *key = @"key";
+    __block NSURL *diskFileURL = nil;
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    
+    [self.cache.diskCache setObject:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object, NSURL *fileURL) {
+        diskFileURL = fileURL;
+        dispatch_semaphore_signal(semaphore);
+    }];
+    
+    dispatch_semaphore_wait(semaphore, [self timeout]);
+    
+    XCTAssertNotNil(diskFileURL.pathExtension);
+    XCTAssertEqualObjects(diskFileURL.pathExtension, @"obj");
+    
+}
+
 @end


### PR DESCRIPTION
Separated from #101 

By default, files are stored using an escaped key. If I provide a serialiser / deserialiser that doesn't perform any operation on NSData objects, I can feed the file URLs directly into other API, in my case AVPlayerItem. Unfortunately, AVPlayerItem is particularly strict when it comes to reading file URLs and requires that there be an extension.

I have added a fileExtension property to PINDiskCache that is used after encoding a key.
