### PR TITLE
Adds PINOperationQueue

### DIFF
--- a/PINCache/PINOperationQueue.h
+++ b/PINCache/PINOperationQueue.h
@@ -1,0 +1,30 @@
+//
+//  PINOperationQueue.h
+//  Pods
+//
+//  Created by Garrett Moon on 8/23/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, PINOperationQueuePriority) {
+  PINOperationQueuePriorityLow,
+  PINOperationQueuePriorityDefault,
+  PINOperationQueuePriorityHigh,
+};
+
+@protocol PINOperationReference;
+
+@interface PINOperationQueue : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithMaxConcurrentOperations:(NSUInteger)maxConcurrentOperations NS_DESIGNATED_INITIALIZER;
+- (id <PINOperationReference>)addOperation:(dispatch_block_t)operation withPriority:(PINOperationQueuePriority)priority;
+- (void)cancelOperation:(id <PINOperationReference>)operationReference;
+
+@end
+
+@protocol PINOperationReference <NSObject>
+
+@end

--- a/PINCache/PINOperationQueue.h
+++ b/PINCache/PINOperationQueue.h
@@ -19,7 +19,8 @@ typedef NS_ENUM(NSUInteger, PINOperationQueuePriority) {
 @interface PINOperationQueue : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithMaxConcurrentOperations:(NSUInteger)maxConcurrentOperations NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithMaxConcurrentOperations:(NSUInteger)maxConcurrentOperations;
+- (instancetype)initWithMaxConcurrentOperations:(NSUInteger)maxConcurrentOperations concurrentQueue:(dispatch_queue_t)concurrentQueue NS_DESIGNATED_INITIALIZER;
 - (id <PINOperationReference>)addOperation:(dispatch_block_t)operation withPriority:(PINOperationQueuePriority)priority;
 - (void)cancelOperation:(id <PINOperationReference>)operationReference;
 

--- a/PINCache/PINOperationQueue.m
+++ b/PINCache/PINOperationQueue.m
@@ -1,0 +1,217 @@
+//
+//  PINOperationQueue.m
+//  Pods
+//
+//  Created by Garrett Moon on 8/23/16.
+//
+//
+
+#import "PINOperationQueue.h"
+#import <pthread.h>
+
+@interface NSNumber (PINOperationQueue) <PINOperationReference>
+
+@end
+
+@interface PINOperationQueue () {
+  pthread_mutex_t _lock;
+  //increments with every operation to allow cancelation
+  NSUInteger _operationReferenceCount;
+  
+  dispatch_queue_t _serialQueue;
+  BOOL _serialQueueBusy;
+  
+  dispatch_semaphore_t _concurrentSemaphore;
+  dispatch_queue_t _concurrentQueue;
+  dispatch_queue_t _semaphoreQueue;
+  
+  NSMutableOrderedSet *_allOperations;
+  NSMutableOrderedSet *_lowPriorityOperations;
+  NSMutableOrderedSet *_defaultPriorityOperations;
+  NSMutableOrderedSet *_highPriorityOperations;
+  
+  NSHashTable *_canceledOperations;
+}
+
+@end
+
+@interface PINOperation : NSObject
+
+@property (nonatomic, strong) dispatch_block_t block;
+@property (nonatomic, strong) id <PINOperationReference> reference;
+
++ (instancetype)operationWithBlock:(dispatch_block_t)block reference:(id <PINOperationReference>)reference;
+
+@end
+
+@implementation PINOperation
+
++ (instancetype)operationWithBlock:(dispatch_block_t)block reference:(id<PINOperationReference>)reference
+{
+  PINOperation *operation = [[self alloc] init];
+  operation.block = block;
+  operation.reference = reference;
+
+  return operation;
+}
+
+@end
+
+@implementation PINOperationQueue
+
+- (instancetype)initWithMaxConcurrentOperations:(NSUInteger)maxConcurrentOperations
+{
+  if (self = [super init]) {
+    NSAssert(maxConcurrentOperations > 1, @"Max concurrent operations must be greater than 1. If it's one, just use a serial queue!");
+    _operationReferenceCount = 0;
+    
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&_lock, &attr);
+    
+    _serialQueue = dispatch_queue_create("PINOperationQueue Serial Queue", DISPATCH_QUEUE_SERIAL);
+    
+    _concurrentQueue = dispatch_queue_create("PINOperationQueue Unprioritized Serial Queue", DISPATCH_QUEUE_CONCURRENT);
+    _concurrentSemaphore = dispatch_semaphore_create(maxConcurrentOperations - 1);
+    _semaphoreQueue = dispatch_queue_create("PINOperationQueue Serial Semaphore Queue", DISPATCH_QUEUE_SERIAL);
+    
+    _allOperations = [[NSMutableOrderedSet alloc] init];
+    _lowPriorityOperations = [[NSMutableOrderedSet alloc] init];
+    _defaultPriorityOperations = [[NSMutableOrderedSet alloc] init];
+    _highPriorityOperations = [[NSMutableOrderedSet alloc] init];
+  }
+  return self;
+}
+
+- (void)dealloc
+{
+  pthread_mutex_destroy(&_lock);
+}
+
+- (id <PINOperationReference>)nextOperationReference
+{
+  [self lock];
+    id <PINOperationReference> reference = [NSNumber numberWithUnsignedInteger:++_operationReferenceCount];
+  [self unlock];
+  return reference;
+}
+
+- (id <PINOperationReference>)addOperation:(dispatch_block_t)block withPriority:(PINOperationQueuePriority)priority
+{
+  id <PINOperationReference> reference = [self nextOperationReference];
+  
+  NSMutableOrderedSet *queue;
+  switch (priority) {
+    case PINOperationQueuePriorityLow:
+      queue = _lowPriorityOperations;
+      break;
+      
+    case PINOperationQueuePriorityDefault:
+      queue = _defaultPriorityOperations;
+      break;
+      
+    case PINOperationQueuePriorityHigh:
+      queue = _highPriorityOperations;
+  }
+  
+  PINOperation *operation = [PINOperation operationWithBlock:block reference:reference];
+  
+  [self lock];
+    [queue addObject:operation];
+    [_allOperations addObject:operation];
+  [self unlock];
+  
+  [self scheduleOperations:NO];
+  
+  return reference;
+}
+
+- (void)cancelOperation:(id <PINOperationReference>)operationReference
+{
+  [self lock];
+    [_canceledOperations addObject:operationReference];
+  [self unlock];
+}
+
+- (void)scheduleOperations:(BOOL)onlyCheckSerial
+{
+  [self lock];
+    //get next available operation in order, ignoring priority and run it on the serial queue
+    if (_serialQueueBusy == NO) {
+      PINOperation *operation = [_allOperations firstObject];
+      if (operation) {
+        _serialQueueBusy = YES;
+        [self removeOperation:operation];
+        dispatch_async(_serialQueue, ^{
+          operation.block();
+          [self lock];
+            _serialQueueBusy = NO;
+          [self unlock];
+          
+          //see if there are any other operations
+          [self scheduleOperations:YES];
+        });
+      }
+    }
+  [self unlock];
+  
+  if (onlyCheckSerial) {
+    return;
+  }
+  
+  dispatch_async(_semaphoreQueue, ^{
+      dispatch_semaphore_wait(_concurrentSemaphore, DISPATCH_TIME_FOREVER);
+      [self lock];
+        PINOperation *operation = [self nextOperationByPriority];
+        [self removeOperation:operation];
+      [self unlock];
+    
+      if (operation) {
+        dispatch_async(_concurrentQueue, ^{
+          operation.block();
+          dispatch_semaphore_signal(_concurrentSemaphore);
+        });
+      } else {
+        dispatch_semaphore_signal(_concurrentSemaphore);
+      }
+  });
+}
+
+//Call with lock held
+- (PINOperation *)nextOperationByPriority
+{
+  PINOperation *operation = [_highPriorityOperations firstObject];
+  if (operation) {
+    return operation;
+  }
+  operation = [_defaultPriorityOperations firstObject];
+  if (operation) {
+    return operation;
+  }
+  operation = [_lowPriorityOperations firstObject];
+  return operation;
+}
+
+//Call with lock held
+- (void)removeOperation:(PINOperation *)operation
+{
+  if (operation) {
+    [_allOperations removeObject:operation];
+    [_lowPriorityOperations removeObject:operation];
+    [_defaultPriorityOperations removeObject:operation];
+    [_highPriorityOperations removeObject:operation];
+  }
+}
+
+- (void)lock
+{
+  pthread_mutex_lock(&_lock);
+}
+
+- (void)unlock
+{
+  pthread_mutex_unlock(&_lock);
+}
+
+@end

--- a/PINCache/PINOperationQueue.m
+++ b/PINCache/PINOperationQueue.m
@@ -61,6 +61,11 @@
 
 - (instancetype)initWithMaxConcurrentOperations:(NSUInteger)maxConcurrentOperations
 {
+  return [self initWithMaxConcurrentOperations:maxConcurrentOperations concurrentQueue:dispatch_queue_create("PINOperationQueue Unprioritized Serial Queue", DISPATCH_QUEUE_CONCURRENT)];
+}
+
+- (instancetype)initWithMaxConcurrentOperations:(NSUInteger)maxConcurrentOperations concurrentQueue:(dispatch_queue_t)concurrentQueue
+{
   if (self = [super init]) {
     NSAssert(maxConcurrentOperations > 1, @"Max concurrent operations must be greater than 1. If it's one, just use a serial queue!");
     _operationReferenceCount = 0;
@@ -72,7 +77,7 @@
     
     _serialQueue = dispatch_queue_create("PINOperationQueue Serial Queue", DISPATCH_QUEUE_SERIAL);
     
-    _concurrentQueue = dispatch_queue_create("PINOperationQueue Unprioritized Serial Queue", DISPATCH_QUEUE_CONCURRENT);
+    _concurrentQueue = concurrentQueue;
     
     //Create a queue with max - 1 because this plus the serial queue add up to max.
     _concurrentSemaphore = dispatch_semaphore_create(maxConcurrentOperations - 1);

--- a/PINCache/PINOperationQueue.m
+++ b/PINCache/PINOperationQueue.m
@@ -72,6 +72,7 @@
     
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
+    //mutex must be recursive to allow scheduling of operations from operations
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
     pthread_mutex_init(&_lock, &attr);
     

--- a/tests/PINCache.xcodeproj/project.pbxproj
+++ b/tests/PINCache.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		662900461A66B830009C10BD /* PINMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = D0E5D83E171DF0AF0041E777 /* PINMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		662900471A66B831009C10BD /* PINDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = D0E5D83C171DF0AF0041E777 /* PINDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		662900481A66B831009C10BD /* PINMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = D0E5D83E171DF0AF0041E777 /* PINMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68E5DD8E1D7394170018CDEE /* PINOperationQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 68E5DD8D1D7394170018CDEE /* PINOperationQueueTests.m */; };
+		68E5DD911D73946D0018CDEE /* PINOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 68E5DD901D73946D0018CDEE /* PINOperationQueue.m */; };
 		692C96731C88C37900CE9C49 /* ActionRequestHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 692C96721C88C37900CE9C49 /* ActionRequestHandler.m */; };
 		692C96751C88C37900CE9C49 /* Action.js in Resources */ = {isa = PBXBuildFile; fileRef = 692C96741C88C37900CE9C49 /* Action.js */; };
 		692C96791C88C37900CE9C49 /* ShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 692C966F1C88C37900CE9C49 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -101,6 +103,9 @@
 		662900141A66B60D009C10BD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6629FFED1A66B512009C10BD /* PINCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PINCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6629FFF01A66B512009C10BD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		68E5DD8D1D7394170018CDEE /* PINOperationQueueTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PINOperationQueueTests.m; sourceTree = "<group>"; };
+		68E5DD8F1D73946D0018CDEE /* PINOperationQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PINOperationQueue.h; sourceTree = "<group>"; };
+		68E5DD901D73946D0018CDEE /* PINOperationQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PINOperationQueue.m; sourceTree = "<group>"; };
 		692C966F1C88C37900CE9C49 /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		692C96711C88C37900CE9C49 /* ActionRequestHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ActionRequestHandler.h; sourceTree = "<group>"; };
 		692C96721C88C37900CE9C49 /* ActionRequestHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ActionRequestHandler.m; sourceTree = "<group>"; };
@@ -313,6 +318,7 @@
 				D07F1EDB171AFB7A001DBA02 /* PINCacheTests-Info.plist */,
 				D07F1EDF171AFB7A001DBA02 /* PINCacheTests.h */,
 				D07F1EE0171AFB7A001DBA02 /* PINCacheTests.m */,
+				68E5DD8D1D7394170018CDEE /* PINOperationQueueTests.m */,
 			);
 			path = PINCacheTests;
 			sourceTree = "<group>";
@@ -323,11 +329,13 @@
 				E0BE3BFD1ABA6B6900B516E5 /* Nullability.h */,
 				D0E5D83A171DF0AF0041E777 /* PINCache.h */,
 				D0E5D83B171DF0AF0041E777 /* PINCache.m */,
+				705DF8571CB03E20004BF1EB /* PINCacheObjectSubscripting.h */,
 				D0E5D83C171DF0AF0041E777 /* PINDiskCache.h */,
 				D0E5D83D171DF0AF0041E777 /* PINDiskCache.m */,
 				D0E5D83E171DF0AF0041E777 /* PINMemoryCache.h */,
 				D0E5D83F171DF0AF0041E777 /* PINMemoryCache.m */,
-				705DF8571CB03E20004BF1EB /* PINCacheObjectSubscripting.h */,
+				68E5DD8F1D73946D0018CDEE /* PINOperationQueue.h */,
+				68E5DD901D73946D0018CDEE /* PINOperationQueue.m */,
 			);
 			name = PINCache;
 			path = ../PINCache;
@@ -629,6 +637,7 @@
 				D0E5D840171DF0AF0041E777 /* PINCache.m in Sources */,
 				D0E5D842171DF0AF0041E777 /* PINDiskCache.m in Sources */,
 				D0E5D844171DF0AF0041E777 /* PINMemoryCache.m in Sources */,
+				68E5DD911D73946D0018CDEE /* PINOperationQueue.m in Sources */,
 				D0E5D848171DF0FA0041E777 /* PINExampleView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -641,6 +650,7 @@
 				D0E5D841171DF0AF0041E777 /* PINCache.m in Sources */,
 				D0E5D843171DF0AF0041E777 /* PINDiskCache.m in Sources */,
 				D0E5D845171DF0AF0041E777 /* PINMemoryCache.m in Sources */,
+				68E5DD8E1D7394170018CDEE /* PINOperationQueueTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/PINCacheTests/PINCacheTests.h
+++ b/tests/PINCacheTests/PINCacheTests.h
@@ -4,6 +4,8 @@
 
 #import <XCTest/XCTest.h>
 
+extern const NSTimeInterval PINCacheTestBlockTimeout;
+
 @interface PINCacheTests : XCTestCase
 
 @end

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -6,7 +6,7 @@
 #import "PINCache.h"
 
 static NSString * const PINCacheTestName = @"PINCacheTest";
-static const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
+const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
 @interface PINDiskCache()
 

--- a/tests/PINCacheTests/PINOperationQueueTests.m
+++ b/tests/PINCacheTests/PINOperationQueueTests.m
@@ -1,0 +1,186 @@
+//
+//  PINOperationQueueTests.m
+//  PINCache
+//
+//  Created by Garrett Moon on 8/28/16.
+//  Copyright © 2016 Pinterest. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <pthread.h>
+
+#import "PINCacheTests.h"
+#import "PINOperationQueue.h"
+
+@interface PINOperationQueueTests : XCTestCase
+
+@property (nonatomic, strong) PINOperationQueue *queue;
+
+@end
+
+static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
+
+@implementation PINOperationQueueTests
+
+- (void)setUp
+{
+  [super setUp];
+  self.queue = [[PINOperationQueue alloc] initWithMaxConcurrentOperations:PINOperationQueueTestsMaxOperations];
+  // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown
+{
+  // Put teardown code here. This method is called after the invocation of each test method in the class.
+  self.queue = nil;
+  [super tearDown];
+}
+
+- (dispatch_time_t)timeout
+{
+  return dispatch_time(DISPATCH_TIME_NOW, (int64_t)(PINCacheTestBlockTimeout * NSEC_PER_SEC));
+}
+
+- (void)testAllOperationsRun
+{
+  const NSUInteger operationCount = 100;
+  dispatch_group_t group = dispatch_group_create();
+  
+  for (NSUInteger count = 0; count < operationCount; count++) {
+    dispatch_group_enter(group);
+    [self.queue addOperation:^{
+      dispatch_group_leave(group);
+    } withPriority:PINOperationQueuePriorityDefault];
+  }
+  
+  NSUInteger success = dispatch_group_wait(group, [self timeout]);
+  XCTAssert(success == 0, @"Timed out before completing 100 operations");
+}
+
+- (void)testMaximumNumberOfConcurrentOperations
+{
+  const NSUInteger operationCount = 100;
+  dispatch_group_t group = dispatch_group_create();
+  
+  __block NSUInteger runningOperationCount = 0;
+  
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+  for (NSUInteger count = 0; count < operationCount; count++) {
+    dispatch_group_enter(group);
+    [self.queue addOperation:^{
+      @synchronized (self) {
+        runningOperationCount++;
+        XCTAssert(runningOperationCount <= PINOperationQueueTestsMaxOperations, @"Running too many operations at once.");
+      }
+      
+      usleep(1000);
+      
+      @synchronized (self) {
+        runningOperationCount--;
+        XCTAssert(runningOperationCount <= PINOperationQueueTestsMaxOperations, @"Running too many operations at once.");
+      }
+      
+      dispatch_group_leave(group);
+    } withPriority:PINOperationQueuePriorityDefault];
+  }
+#pragma clang diagnostic pop
+  
+  NSUInteger success = dispatch_group_wait(group, [self timeout]);
+  XCTAssert(success == 0, @"Timed out before completing 100 operations");
+}
+
+//We expect operations to run in priority order when added in that order as well
+- (void)testPriority
+{
+  const NSUInteger highOperationCount = 100;
+  const NSUInteger defaultOperationCount = 100;
+  const NSUInteger lowOperationCount = 100;
+  
+  __block NSUInteger highOperationComplete = 0;
+  __block NSUInteger defaultOperationComplete = 0;
+  __block NSUInteger lowOperationComplete = 0;
+  
+  dispatch_group_t group = dispatch_group_create();
+  
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+  for (NSUInteger count = 0; count < highOperationCount; count++) {
+    dispatch_group_enter(group);
+    [self.queue addOperation:^{
+      @synchronized (self) {
+        ++highOperationComplete;
+        XCTAssert(defaultOperationComplete < PINOperationQueueTestsMaxOperations, @"Running default operations before high");
+        XCTAssert(lowOperationComplete < PINOperationQueueTestsMaxOperations, @"Running low operations before high");
+      }
+      dispatch_group_leave(group);
+    } withPriority:PINOperationQueuePriorityHigh];
+  }
+  
+  for (NSUInteger count = 0; count < defaultOperationCount; count++) {
+    dispatch_group_enter(group);
+    [self.queue addOperation:^{
+      @synchronized (self) {
+        ++defaultOperationComplete;
+        XCTAssert(lowOperationComplete < PINOperationQueueTestsMaxOperations, @"Running low operations before default");
+        XCTAssert(highOperationComplete > highOperationCount - PINOperationQueueTestsMaxOperations, @"Running high operations after default");
+      }
+      dispatch_group_leave(group);
+    } withPriority:PINOperationQueuePriorityDefault];
+  }
+  
+  for (NSUInteger count = 0; count < lowOperationCount; count++) {
+    dispatch_group_enter(group);
+    [self.queue addOperation:^{
+      @synchronized (self) {
+        ++lowOperationComplete;
+        XCTAssert(defaultOperationComplete > defaultOperationCount - PINOperationQueueTestsMaxOperations, @"Running default operations after low");
+        XCTAssert(highOperationComplete > highOperationCount - PINOperationQueueTestsMaxOperations, @"Running high operations after low");
+      }
+      dispatch_group_leave(group);
+    } withPriority:PINOperationQueuePriorityLow];
+  }
+#pragma clang diagnostic pop
+  
+  NSUInteger success = dispatch_group_wait(group, [self timeout]);
+  XCTAssert(success == 0, @"Timed out");
+}
+
+//We expect low priority operations to eventually run even if the queue is continually kept full with higher priority operations
+- (void)testOutOfOrderOperations
+{
+  const NSUInteger operationCount = 100;
+  dispatch_group_t group = dispatch_group_create();
+  
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+  for (NSUInteger count = 0; count < PINOperationQueueTestsMaxOperations + 1; count++) {
+    [self.queue addOperation:^{
+      [self recursivelyAddOperation];
+    } withPriority:PINOperationQueuePriorityHigh];
+  }
+#pragma clang diagnostic pop
+  
+  for (NSUInteger count = 0; count < operationCount; count++) {
+    dispatch_group_enter(group);
+    [self.queue addOperation:^{
+      dispatch_group_leave(group);
+    } withPriority:PINOperationQueuePriorityLow];
+  }
+  
+  NSUInteger success = dispatch_group_wait(group, [self timeout]);
+  XCTAssert(success == 0, @"Timed out");
+}
+
+- (void)recursivelyAddOperation
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+  [self.queue addOperation:^{
+    [self recursivelyAddOperation];
+  } withPriority:PINOperationQueuePriorityHigh];
+#pragma clang diagnostic pop
+}
+
+@end

--- a/tests/PINCacheTests/PINOperationQueueTests.m
+++ b/tests/PINCacheTests/PINOperationQueueTests.m
@@ -183,4 +183,25 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
 #pragma clang diagnostic pop
 }
 
+- (void)testCancelation
+{
+  const NSUInteger sleepTime = 100000;
+  for (NSUInteger count = 0; count < PINOperationQueueTestsMaxOperations + 1; count++) {
+    [self.queue addOperation:^{
+      usleep(sleepTime);
+    } withPriority:PINOperationQueuePriorityDefault];
+  }
+  
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+  id <PINOperationReference> operation = [self.queue addOperation:^{
+    XCTAssertTrue(NO, @"operation should have been canceled");
+  } withPriority:PINOperationQueuePriorityDefault];
+#pragma clang diagnostics pop
+  
+  [self.queue cancelOperation:operation];
+  
+  usleep(sleepTime * (PINOperationQueueTestsMaxOperations + 1));
+}
+
 @end

--- a/tests/PINCacheTests/PINOperationQueueTests.m
+++ b/tests/PINCacheTests/PINOperationQueueTests.m
@@ -111,8 +111,8 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
     [self.queue addOperation:^{
       @synchronized (self) {
         ++highOperationComplete;
-        XCTAssert(defaultOperationComplete < PINOperationQueueTestsMaxOperations, @"Running default operations before high");
-        XCTAssert(lowOperationComplete < PINOperationQueueTestsMaxOperations, @"Running low operations before high");
+        XCTAssert(defaultOperationComplete <= PINOperationQueueTestsMaxOperations, @"Running default operations before high");
+        XCTAssert(lowOperationComplete <= PINOperationQueueTestsMaxOperations, @"Running low operations before high");
       }
       dispatch_group_leave(group);
     } withPriority:PINOperationQueuePriorityHigh];
@@ -123,7 +123,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
     [self.queue addOperation:^{
       @synchronized (self) {
         ++defaultOperationComplete;
-        XCTAssert(lowOperationComplete < PINOperationQueueTestsMaxOperations, @"Running low operations before default");
+        XCTAssert(lowOperationComplete <= PINOperationQueueTestsMaxOperations, @"Running low operations before default");
         XCTAssert(highOperationComplete > highOperationCount - PINOperationQueueTestsMaxOperations, @"Running high operations after default");
       }
       dispatch_group_leave(group);


### PR DESCRIPTION
PINOperationQueue is an operation queue designed to allow
specifying the maximum number of threads, support priority (ordering,
not thread priority and cancelation).

It is also designed to prevent live locks due to priority inversion.
It attempts to achieve this by maintaining two queues: a serial queue
which always takes operations in FIFO order and a concurrent queue
which runs operations in priority order.