### PR TITLE
Add waitUntilAllOperationsAreFinished to PINOperationQueue

### DIFF
--- a/PINCache/PINOperationQueue.h
+++ b/PINCache/PINOperationQueue.h
@@ -23,6 +23,16 @@ typedef NS_ENUM(NSUInteger, PINOperationQueuePriority) {
 - (instancetype)initWithMaxConcurrentOperations:(NSUInteger)maxConcurrentOperations concurrentQueue:(dispatch_queue_t)concurrentQueue NS_DESIGNATED_INITIALIZER;
 - (id <PINOperationReference>)addOperation:(dispatch_block_t)operation withPriority:(PINOperationQueuePriority)priority;
 - (void)cancelOperation:(id <PINOperationReference>)operationReference;
+
+/**
+ * Blocks the current thread until all of the receiver’s queued and executing operations finish executing.
+ *
+ * @discussion When called, this method blocks the current thread and waits for the receiver’s current and queued
+ * operations to finish executing. While the current thread is blocked, the receiver continues to launch already
+ * queued operations and monitor those that are executing.
+ */
+- (void)waitUntilAllOperationsAreFinished;
+
 - (void)setOperationPriority:(PINOperationQueuePriority)priority withReference:(id <PINOperationReference>)reference;
 
 @end

--- a/PINCache/PINOperationQueue.h
+++ b/PINCache/PINOperationQueue.h
@@ -30,6 +30,9 @@ typedef NS_ENUM(NSUInteger, PINOperationQueuePriority) {
  * @discussion When called, this method blocks the current thread and waits for the receiver’s current and queued
  * operations to finish executing. While the current thread is blocked, the receiver continues to launch already
  * queued operations and monitor those that are executing.
+ *
+ * @warning This should never be called from within an operation submitted to the PINOperationQueue as this will result
+ * in a deadlock.
  */
 - (void)waitUntilAllOperationsAreFinished;
 

--- a/PINCache/PINOperationQueue.m
+++ b/PINCache/PINOperationQueue.m
@@ -141,7 +141,7 @@
       NSMutableOrderedSet *queue = [self operationQueueWithPriority:operation.priority];
       [queue removeObject:operation];
       [_queuedOperations removeObject:operation];
-      dispatch_group_leave(_group); // Add operation to queue
+      dispatch_group_leave(_group);
     }
   [self unlock];
 }

--- a/tests/PINCacheTests/PINOperationQueueTests.m
+++ b/tests/PINCacheTests/PINOperationQueueTests.m
@@ -61,17 +61,16 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
 - (void)testWaitUntilAllOperationsFinished
 {
   const NSUInteger operationCount = 100;
-  __block NSInteger runnedOperations = 0;;
+  __block NSInteger operationsRun = 0;;
   for (NSUInteger count = 0; count < operationCount; count++) {
     [self.queue addOperation:^{
-      runnedOperations += 1;
+      operationsRun += 1;
     } withPriority:PINOperationQueuePriorityDefault];
   }
   
-  //
   [self.queue waitUntilAllOperationsAreFinished];
   
-  XCTAssert(operationCount == runnedOperations, @"Timed out before completing 100 operations");
+  XCTAssert(operationCount == operationsRun, @"Timed out before completing 100 operations");
 }
 
 - (void)testWaitUntilAllOperationsFinishedWithNestedOperations
@@ -90,7 +89,6 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
     } withPriority:PINOperationQueuePriorityDefault];
   }
 
-  //
   [self.queue waitUntilAllOperationsAreFinished];
 
   XCTAssert(runnedOperations == (operationCount*2), @"Timed out before completing 100 operations");


### PR DESCRIPTION
Adding `waitUntilAllOperationsAreFinished` to `PINOperationQueue`. Should work the same as `waitUntilAllOperationsAreFinished` of `NSOperationQueue`

One use case could be if the operation queue is used as a transaction.