### PR TITLE
Add cancelAllOperations to PINOperationQueue

### DIFF
--- a/PINCache/PINOperationQueue.h
+++ b/PINCache/PINOperationQueue.h
@@ -22,7 +22,17 @@ typedef NS_ENUM(NSUInteger, PINOperationQueuePriority) {
 - (instancetype)initWithMaxConcurrentOperations:(NSUInteger)maxConcurrentOperations;
 - (instancetype)initWithMaxConcurrentOperations:(NSUInteger)maxConcurrentOperations concurrentQueue:(dispatch_queue_t)concurrentQueue NS_DESIGNATED_INITIALIZER;
 - (id <PINOperationReference>)addOperation:(dispatch_block_t)operation withPriority:(PINOperationQueuePriority)priority;
+
+/**
+ * Marks the operation as cancelled
+ */
 - (void)cancelOperation:(id <PINOperationReference>)operationReference;
+
+/**
+ * Cancels all queued operations
+ */
+- (void)cancelAllOperations;
+
 - (void)setOperationPriority:(PINOperationQueuePriority)priority withReference:(id <PINOperationReference>)reference;
 
 @end

--- a/PINCache/PINOperationQueue.m
+++ b/PINCache/PINOperationQueue.m
@@ -131,9 +131,9 @@
 - (void)cancelAllOperations
 {
   [self lock];
-  for (PINOperation *operation in [_referenceToOperations objectEnumerator]) {
-    [self locked_cancelOperation:operation.reference];
-  }
+    for (PINOperation *operation in [[_referenceToOperations copy] objectEnumerator]) {
+      [self locked_cancelOperation:operation.reference];
+    }
   [self unlock];
 }
 

--- a/PINCache/PINOperationQueue.m
+++ b/PINCache/PINOperationQueue.m
@@ -128,16 +128,31 @@
   return reference;
 }
 
+- (void)cancelAllOperations
+{
+  [self lock];
+  for (PINOperation *operation in [_referenceToOperations objectEnumerator]) {
+    [self locked_cancelOperation:operation.reference];
+  }
+  [self unlock];
+}
+
+
 - (void)cancelOperation:(id <PINOperationReference>)operationReference
 {
   [self lock];
-    PINOperation *operation = [_referenceToOperations objectForKey:operationReference];
-    if (operation) {
-      NSMutableOrderedSet *queue = [self operationQueueWithPriority:operation.priority];
-      [queue removeObject:operation];
-      [_queuedOperations removeObject:operation];
-    }
+    [self locked_cancelOperation:operationReference];
   [self unlock];
+}
+
+- (void)locked_cancelOperation:(id <PINOperationReference>)operationReference
+{
+  PINOperation *operation = [_referenceToOperations objectForKey:operationReference];
+  if (operation) {
+    NSMutableOrderedSet *queue = [self operationQueueWithPriority:operation.priority];
+    [queue removeObject:operation];
+    [_queuedOperations removeObject:operation];
+  }
 }
 
 - (void)setOperationPriority:(PINOperationQueuePriority)priority withReference:(id <PINOperationReference>)operationReference


### PR DESCRIPTION
Add support to cancel all operations. Furthermore created a new method for cancelling an operation that the lock needs to be hold. This used by `cancelOperation` as well as `cancelAllOperations` now.