### PR TITLE
Have sharedOperationQueue have at least 2 max operations.

### DIFF
--- a/PINCache/PINOperationQueue.m
+++ b/PINCache/PINOperationQueue.m
@@ -112,7 +112,7 @@
     static PINOperationQueue *sharedOperationQueue = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        sharedOperationQueue = [[PINOperationQueue alloc] initWithMaxConcurrentOperations:[[NSProcessInfo processInfo] activeProcessorCount]];
+        sharedOperationQueue = [[PINOperationQueue alloc] initWithMaxConcurrentOperations:MAX([[NSProcessInfo processInfo] activeProcessorCount], 2)];
     });
     return sharedOperationQueue;
 }


### PR DESCRIPTION
On devices without multiple cores it's still useful to allow multiple
operations to run at once.

Hopefully addresses #134 134