### PR TITLE
Increase max operation count to 10

### DIFF
--- a/PINCache/PINCache.m
+++ b/PINCache/PINCache.m
@@ -47,7 +47,8 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     if (self = [super init]) {
         _name = [name copy];
       
-        _operationQueue = [[PINOperationQueue alloc] initWithMaxConcurrentOperations:5];
+        //10 may actually be a bit high, but currently much of our threads are blocked on empyting the trash. Until we can resolve that, lets bump this up.
+        _operationQueue = [[PINOperationQueue alloc] initWithMaxConcurrentOperations:10];
       
         _diskCache = [[PINDiskCache alloc] initWithName:_name rootPath:rootPath serializer:serializer deserializer:deserializer fileExtension:fileExtension operationQueue:_operationQueue];
         _memoryCache = [[PINMemoryCache alloc] initWithOperationQueue:_operationQueue];


### PR DESCRIPTION
On lower end devices most operations end up being empty trash operations.
That issue needs to be addressed, but in the meantime, lets bump this
number up.