### PR TITLE
Optimize trash emptying in disk cache

### DIFF
--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -282,7 +282,7 @@ static NSURL *_sharedTrashURL;
 
 + (NSURL *)sharedTrashURL
 {
-    NSURL *trashURL;
+    NSURL *trashURL = nil;
     
     [[PINDiskCache sharedLock] lock];
         if (_sharedTrashURL == nil) {
@@ -318,8 +318,11 @@ static NSURL *_sharedTrashURL;
 + (void)emptyTrash
 {
     dispatch_async([PINDiskCache sharedTrashQueue], ^{
-        NSURL *trashURL;
-        
+        NSURL *trashURL = nil;
+      
+        // If _sharedTrashURL is unset, there's nothing left to do because it hasn't been accessed and therefore items haven't been added to it.
+        // If it is set, we can just remove it.
+        // We also need to nil out _sharedTrashURL so that a new one will be created if there's an attempt to move a new file to the trash.
         [[PINDiskCache sharedLock] lock];
             if (_sharedTrashURL != nil) {
                 trashURL = _sharedTrashURL;

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -33,11 +33,17 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
 - (void)tearDown
 {
-    [self.cache removeAllObjects];
-    
-    // Disk cache needs a bit more time to clean up its trash 
-    sleep(1);
+    dispatch_group_t group = dispatch_group_create();
+    dispatch_group_enter(group);
 
+    [self.cache removeAllObjects];
+
+    // Wait for disk cache to clean up its trash
+    dispatch_async([PINDiskCache sharedTrashQueue], ^{
+        dispatch_group_leave(group);
+    });
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+  
     self.cache = nil;
 
     XCTAssertNil(self.cache, @"test cache did not deallocate");

--- a/tests/PINCacheTests/PINCacheTests.m
+++ b/tests/PINCacheTests/PINCacheTests.m
@@ -10,6 +10,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
 @interface PINDiskCache()
 
++ (dispatch_queue_t)sharedTrashQueue;
 - (NSString *)encodedString:(NSString *)string;
 
 @end
@@ -33,6 +34,9 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 - (void)tearDown
 {
     [self.cache removeAllObjects];
+    
+    // Disk cache needs a bit more time to clean up its trash 
+    sleep(1);
 
     self.cache = nil;
 
@@ -876,6 +880,48 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
       [testCache objectForKey:[@(idx) stringValue]];
     }
   }];
+}
+
+- (void)testDiskCacheEmptyTrash
+{
+    const NSUInteger fileCount = 100;
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *tempDirPath = NSTemporaryDirectory();
+    
+    dispatch_group_t group = dispatch_group_create();
+    
+    NSError *error = nil;
+    unsigned long long originalTempDirSize = [[fileManager attributesOfItemAtPath:tempDirPath error:&error] fileSize];
+    XCTAssertNil(error);
+    
+    for (int i = 0; i < fileCount; i++) {
+        NSString *key = [NSString stringWithFormat:@"key%d", i];
+        self.cache.diskCache[key] = key;
+    }
+    
+    dispatch_group_enter(group);
+    [self.cache.diskCache removeAllObjects:^(PINDiskCache * _Nonnull cache) {
+        // Temporary directory should be bigger now since the trash directory is still inside it
+        NSError *error = nil;
+        unsigned long long tempDirSize = [[fileManager attributesOfItemAtPath:tempDirPath error:&error] fileSize];
+        XCTAssertNil(error);
+        XCTAssertLessThan(originalTempDirSize, tempDirSize);
+        
+        // Temporary directory should get back to its original size at the end of the trash queue
+        dispatch_group_enter(group);
+        dispatch_async([PINDiskCache sharedTrashQueue], ^{
+            NSError *error = nil;
+            unsigned long long tempDirSize = [[fileManager attributesOfItemAtPath:tempDirPath error:&error] fileSize];
+            XCTAssertNil(error);
+            XCTAssertEqual(originalTempDirSize, tempDirSize);
+            dispatch_group_leave(group);
+        });
+        
+        dispatch_group_leave(group);
+    }];
+    
+    NSUInteger success = dispatch_group_wait(group, [self timeout]);
+    XCTAssert(success == 0, @"Timed out");
 }
 
 @end


### PR DESCRIPTION
Disk cache now removes its trash directory as a whole instead of removing files inside one by one #136, #137.