### PR TITLE
Support PINMemoryCache cost methods in PINCache

### DIFF
--- a/PINCache/PINCache.h
+++ b/PINCache/PINCache.h
@@ -165,6 +165,19 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
 
 /**
+ Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
+ to go over the <memoryCache.costLimit> the cache is trimmed (oldest objects first). This method returns immediately
+ and executes the passed block after the object has been stored, potentially in parallel with other blocks
+ on the <concurrentQueue>.
+ 
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param cost An amount to add to the <memoryCache.totalCost>.
+ @param block A block to be executed concurrently after the object has been stored, or nil.
+ */
+- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
+
+/**
  Removes the object for the specified key. This method returns immediately and executes the passed
  block after the object has been removed, potentially in parallel with other blocks on the <concurrentQueue>.
  
@@ -221,6 +234,17 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key A key to associate with the object. This string will be copied.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
+
+/**
+ Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
+ to go over the <memoryCache.costLimit> the cache is trimmed (oldest objects first). This method blocks the calling thread
+ until the object has been stored.
+ 
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param cost An amount to add to the <memoryCache.totalCost>.
+ */
+- (void)setObject:(nullable id)object forKey:(nullable NSString *)key withCost:(NSUInteger)cost;
 
 /**
  Removes the object for the specified key. This method blocks the calling thread until the object

--- a/PINCache/PINCache.h
+++ b/PINCache/PINCache.h
@@ -175,7 +175,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param cost An amount to add to the <memoryCache.totalCost>.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed
@@ -244,7 +244,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key A key to associate with the object. This string will be copied.
  @param cost An amount to add to the <memoryCache.totalCost>.
  */
-- (void)setObject:(nullable id)object forKey:(nullable NSString *)key withCost:(NSUInteger)cost;
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost;
 
 /**
  Removes the object for the specified key. This method blocks the calling thread until the object

--- a/PINCache/PINCache.m
+++ b/PINCache/PINCache.m
@@ -143,7 +143,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [self setObject:object forKey:key withCost:0 block:block];
 }
 
-- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
 {
     if (!key || !object)
         return;
@@ -278,7 +278,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [self setObject:object forKey:key withCost:0];
 }
 
-- (void)setObject:(nullable id)object forKey:(nullable NSString *)key withCost:(NSUInteger)cost
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost
 {
     if (!key || !object)
         return;

--- a/PINCache/PINCache.m
+++ b/PINCache/PINCache.m
@@ -140,13 +140,18 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
+    [self setObject:object forKey:key withCost:0 block:block];
+}
+
+- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
+{
     if (!key || !object)
         return;
   
     PINOperationGroup *group = [PINOperationGroup asyncOperationGroupWithQueue:_operationQueue];
     
     [group addOperation:^{
-        [_memoryCache setObject:object forKey:key];
+        [_memoryCache setObject:object forKey:key withCost:cost];
     }];
     [group addOperation:^{
         [_diskCache setObject:object forKey:key];
@@ -270,10 +275,15 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key
 {
+    [self setObject:object forKey:key withCost:0];
+}
+
+- (void)setObject:(nullable id)object forKey:(nullable NSString *)key withCost:(NSUInteger)cost
+{
     if (!key || !object)
         return;
     
-    [_memoryCache setObject:object forKey:key];
+    [_memoryCache setObject:object forKey:key withCost:cost];
     [_diskCache setObject:object forKey:key];
 }
 


### PR DESCRIPTION
This PR addresses issue #64 to expose methods on `PINCache` that accept a memory cache cost argument.