### PR TITLE
Buck improvements

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -6,11 +6,14 @@
   iphonesimulator_target_sdk_version = 5.0
   iphoneos_target_sdk_version = 5.0
   macosx_target_sdk_version = 10.7
+  xctool_default_destination_specifier = platform=iOS Simulator, name=iPhone 6, OS=10.2
 
 [alias]
-  library = //:PINCache
+  lib = //:PINCache
+  tests = //tests:Tests
 
 [project]
+  parallel_parsing = true
   ide = xcode
   ignore = .buckd, \
            .hg, \

--- a/BUCK
+++ b/BUCK
@@ -1,102 +1,23 @@
-COMMON_PREPROCESSOR_FLAGS = ['-fobjc-arc', '-Wno-deprecated-declarations', '-Wignored-attributes']
-
-apple_library(
-  name = 'PINCacheCore',
-  exported_headers = glob([
-    'PINCache/*.h',
-  ]),
-  header_path_prefix = 'PINCache',
-  srcs = glob([
-    'PINCache/*.m',
-  ]),
-  lang_preprocessor_flags = {
-    'C': ['-std=gnu99'],
-    'CXX': ['-std=gnu++11'],
-  },
-  preprocessor_flags = COMMON_PREPROCESSOR_FLAGS,
-  frameworks = [
-    '$SDKROOT/System/Library/Frameworks/Foundation.framework',
-  ],
-  visibility = [
-    'PUBLIC',
-  ],
-)
-
-#PINCache iOS
 apple_library(
   name = 'PINCache',
-  deps = [':PINCacheCore'],
+  exported_headers = glob(['PINCache/*.h']),
+  # PINDiskCache.m should be compiled with '-fobjc-arc-exceptions' (#105)
+  srcs =
+    glob(['PINCache/*.m'], excludes = ['PINCache/PINDiskCache.m']) +
+    [('PINCache/PINDiskCache.m', ['-fobjc-arc-exceptions'])],
+  preprocessor_flags = ['-fobjc-arc'],
+  lang_preprocessor_flags = {
+    'C': ['-std=gnu99'],
+    'CXX': ['-std=gnu++11', '-stdlib=libc++'],
+  },
   linker_flags = [
     '-weak_framework',
     'UIKit',
-  ],
-  visibility = [
-    'PUBLIC',
-  ],
-)
-
-#PINCache MacOS
-apple_library(
-  name = 'PINCacheMacOS',
-  deps = [':PINCacheCore'],
-  linker_flags = [
     '-weak_framework',
     'AppKit',
   ],
-  visibility = [
-    'PUBLIC',
-  ],
-)
-
-apple_resource(
-  name = 'TestAppResources',
-  files = glob(['tests/PINCache/*.png']),
-  dirs = [],
-)
-
-apple_bundle(
-  name = 'TestApp',
-  binary = ':TestAppBinary',
-  extension = 'app',
-  info_plist = 'tests/PINCache/PINCache-Info.plist',
-  tests = [':Tests'],
-)
-
-apple_binary(
-  name = 'TestAppBinary',
-  prefix_header = 'tests/PINCache/PINCache-Prefix.pch',
-  headers = glob([
-    'tests/PINCache/*.h',
-  ]),
-  srcs = glob([
-    'tests/PINCache/*.m',
-  ]),
-  deps = [
-    ':TestAppResources',
-    ':PINCache',
-  ],
-  frameworks = [
-    '$SDKROOT/System/Library/Frameworks/UIKit.framework',
-    '$SDKROOT/System/Library/Frameworks/Foundation.framework',
-  ],
-)
-
-apple_package(
-  name = 'TestAppPackage',
-  bundle = ':TestApp',
-)
-
-apple_test(
-  name = 'Tests',
-  test_host_app = ':TestApp',
-  srcs = glob([
-    'tests/PINCacheTests/*.m'
-  ]),
-  info_plist = 'tests/PINCacheTests/PINCacheTests-Info.plist',
-  preprocessor_flags = COMMON_PREPROCESSOR_FLAGS,
   frameworks = [
     '$SDKROOT/System/Library/Frameworks/Foundation.framework',
-    '$SDKROOT/System/Library/Frameworks/UIKit.framework',
-    '$PLATFORM_DIR/Developer/Library/Frameworks/XCTest.framework',
   ],
+  visibility = ['PUBLIC'],
 )

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -1,0 +1,46 @@
+apple_resource(
+  name = 'TestAppResources',
+  files = glob(['PINCache/*.png']),
+  dirs = [],
+)
+
+apple_bundle(
+  name = 'TestApp',
+  binary = ':TestAppBinary',
+  extension = 'app',
+  info_plist = 'PINCache/PINCache-Info.plist',
+  tests = [':Tests'],
+)
+
+apple_binary(
+  name = 'TestAppBinary',
+  prefix_header = 'PINCache/PINCache-Prefix.pch',
+  headers = glob(['PINCache/*.h']),
+  srcs = glob(['PINCache/*.m']),
+  deps = [
+    ':TestAppResources',
+    '//:PINCache',
+  ],
+  frameworks = [
+    '$SDKROOT/System/Library/Frameworks/UIKit.framework',
+    '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+  ],
+)
+
+apple_package(
+  name = 'TestAppPackage',
+  bundle = ':TestApp',
+)
+
+apple_test(
+  name = 'Tests',
+  test_host_app = ':TestApp',
+  srcs = glob(['PINCacheTests/*.m']),
+  info_plist = 'PINCacheTests/PINCacheTests-Info.plist',
+  preprocessor_flags = ['-fobjc-arc'],
+  frameworks = [
+    '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+    '$SDKROOT/System/Library/Frameworks/UIKit.framework',
+    '$PLATFORM_DIR/Developer/Library/Frameworks/XCTest.framework',
+  ],
+)


### PR DESCRIPTION
- Merge PINCacheCore, PINCache and PINCacheMacOS targets into a single target.
- Compile PINDishCache.m with -fobjc-arc-exceptions flag.
- Move test targets to a separate BUCK file. The main BUCK file can be re-used by users in their own projects after dependency resolution (i.e via CocoaPods).
- Remove unnecessary preprocessor flags.
- Now that we have multiple BUCK files, parse them in parallel.
- Specify default xctool destination.