### PR TITLE
Expose cache URL class method and allow specification of name prefix

### DIFF
--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -80,12 +80,26 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
 
 
 #pragma mark -
+
+/**
+ @param rootPath The path for where the cache should be stored.
+ @param prefix The prefix for the cache name.
+ @param name The name of the cache.
+ @result The full URL of the cache.
+ */
++ (NSURL *)cacheURLWithRootPath:(NSString *)rootPath prefix:(NSString *)prefix name:(NSString *)name;
+
 /// @name Core
 
 /**
  The name of this cache, used to create a directory under Library/Caches and also appearing in stack traces.
  */
 @property (readonly) NSString *name;
+
+/**
+ The prefix to the name of this cache, used to create a directory under Library/Caches and also appearing in stack traces.
+ */
+@property (readonly) NSString *prefix;
 
 /**
  The URL of the directory used by this cache, usually `Library/Caches/com.pinterest.PINDiskCache.(name)`
@@ -265,7 +279,22 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  @param operationQueue A PINOperationQueue to run asynchronous operations
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer fileExtension:(nullable NSString *)fileExtension operationQueue:(nonnull PINOperationQueue *)operationQueue NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer fileExtension:(nullable NSString *)fileExtension operationQueue:(nonnull PINOperationQueue *)operationQueue __attribute__((deprecated));
+
+/**
+ The designated initializer allowing you to override default NSKeyedArchiver/NSKeyedUnarchiver serialization.
+ 
+ @see name
+ @param name The name of the cache.
+ @param prefix The prefix for the cache name. Defaults to com.pinterest.PINDiskCache
+ @param rootPath The path of the cache.
+ @param serializer   A block used to serialize object. If nil provided, default NSKeyedArchiver serialized will be used.
+ @param deserializer A block used to deserialize object. If nil provided, default NSKeyedUnarchiver serialized will be used.
+ @param fileExtension The file extension for files on disk.
+ @param operationQueue A PINOperationQueue to run asynchronous operations
+ @result A new cache with the specified name.
+ */
+- (instancetype)initWithName:(nonnull NSString *)name prefix:(nonnull NSString *)prefix rootPath:(nonnull NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer fileExtension:(nullable NSString *)fileExtension operationQueue:(nonnull PINOperationQueue *)operationQueue NS_DESIGNATED_INITIALIZER;
 
 #pragma mark -
 /// @name Asynchronous Methods

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -98,7 +98,23 @@ static NSURL *_sharedTrashURL;
     return [self initWithName:name rootPath:rootPath serializer:serializer deserializer:deserializer fileExtension:fileExtension operationQueue:[PINOperationQueue sharedOperationQueue]];
 }
 
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(PINDiskCacheSerializerBlock)serializer deserializer:(PINDiskCacheDeserializerBlock)deserializer fileExtension:(NSString *)fileExtension operationQueue:(PINOperationQueue *)operationQueue
+- (instancetype)initWithName:(NSString *)name
+                    rootPath:(NSString *)rootPath
+                  serializer:(PINDiskCacheSerializerBlock)serializer
+                deserializer:(PINDiskCacheDeserializerBlock)deserializer
+               fileExtension:(NSString *)fileExtension
+              operationQueue:(PINOperationQueue *)operationQueue
+{
+  return [self initWithName:name prefix:PINDiskCachePrefix rootPath:rootPath serializer:serializer deserializer:deserializer fileExtension:fileExtension operationQueue:operationQueue];
+}
+
+- (instancetype)initWithName:(NSString *)name
+                      prefix:(NSString *)prefix
+                    rootPath:(NSString *)rootPath
+                  serializer:(PINDiskCacheSerializerBlock)serializer
+                deserializer:(PINDiskCacheDeserializerBlock)deserializer
+               fileExtension:(NSString *)fileExtension
+              operationQueue:(PINOperationQueue *)operationQueue
 {
     if (!name)
         return nil;
@@ -111,6 +127,7 @@ static NSURL *_sharedTrashURL;
     
     if (self = [super init]) {
         _name = [name copy];
+        _prefix = [prefix copy];
         _fileExtension = [fileExtension copy];
         _operationQueue = operationQueue;
         _instanceLock = [[NSConditionLock alloc] initWithCondition:PINDiskCacheConditionNotReady];
@@ -131,9 +148,8 @@ static NSURL *_sharedTrashURL;
         
         _dates = [[NSMutableDictionary alloc] init];
         _sizes = [[NSMutableDictionary alloc] init];
-        
-        NSString *pathComponent = [[NSString alloc] initWithFormat:@"%@.%@", PINDiskCachePrefix, _name];
-        _cacheURL = [NSURL fileURLWithPathComponents:@[ rootPath, pathComponent ]];
+      
+        _cacheURL = [[self class] cacheURLWithRootPath:rootPath prefix:_prefix name:_name];
         
         //setup serializers
         if(serializer) {
@@ -175,6 +191,12 @@ static NSURL *_sharedTrashURL;
     });
     
     return cache;
+}
+
++ (NSURL *)cacheURLWithRootPath:(NSString *)rootPath prefix:(NSString *)prefix name:(NSString *)name
+{
+    NSString *pathComponent = [[NSString alloc] initWithFormat:@"%@.%@", prefix, name];
+    return [NSURL fileURLWithPathComponents:@[ rootPath, pathComponent ]];
 }
 
 #pragma mark - Private Methods -


### PR DESCRIPTION
This exposes a method which given the parameters you would pass into
PINDiskCache would allow you to know the URL the disk cache will end
up being at.

It also allows setting the cache name prefix so it can be your application
identifier instead of com.pinterest.PINDiskCache.(name)