### PR TITLE
Update Objective-C, Prohibit Subclassing

### DIFF
--- a/PINCache.xcodeproj/project.pbxproj
+++ b/PINCache.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		CC0106CC1E28249C00890935 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = CC0106CA1E28248800890935 /* Default-568h@2x.png */; };
 		CC0106CD1E28249C00890935 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = CC0106CA1E28248800890935 /* Default-568h@2x.png */; };
 		CC0106CE1E28249D00890935 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = CC0106CA1E28248800890935 /* Default-568h@2x.png */; };
+		CCBD05DA1E4136D800D18509 /* PINCacheMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = CCBD05D91E4136D000D18509 /* PINCacheMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CCBD05DB1E4136D900D18509 /* PINCacheMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = CCBD05D91E4136D000D18509 /* PINCacheMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CCBD05DC1E4136D900D18509 /* PINCacheMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = CCBD05D91E4136D000D18509 /* PINCacheMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -183,6 +186,7 @@
 		CC0106C51E281D6900890935 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CC0106C91E28228300890935 /* PINCacheTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheTests.h; sourceTree = "<group>"; };
 		CC0106CA1E28248800890935 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
+		CCBD05D91E4136D000D18509 /* PINCacheMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheMacros.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -246,6 +250,7 @@
 				CC0105B21E271A1600890935 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		CC0105B21E271A1600890935 /* Products */ = {
 			isa = PBXGroup;
@@ -264,6 +269,7 @@
 			isa = PBXGroup;
 			children = (
 				CC0106441E281B0E00890935 /* Info.plist */,
+				CCBD05D91E4136D000D18509 /* PINCacheMacros.h */,
 				CC0106051E271A9000890935 /* PINCache.h */,
 				CC0106061E271A9000890935 /* PINCache.m */,
 				CC0106071E271A9000890935 /* PINCacheObjectSubscripting.h */,
@@ -595,6 +601,7 @@
 				CC0106181E271AAF00890935 /* PINCacheObjectSubscripting.h in Headers */,
 				CC01061A1E271AAF00890935 /* PINMemoryCache.h in Headers */,
 				CC0106191E271AAF00890935 /* PINDiskCache.h in Headers */,
+				CCBD05DA1E4136D800D18509 /* PINCacheMacros.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -606,6 +613,7 @@
 				CC01061C1E271AB000890935 /* PINCacheObjectSubscripting.h in Headers */,
 				CC01061E1E271AB000890935 /* PINMemoryCache.h in Headers */,
 				CC01061D1E271AB000890935 /* PINDiskCache.h in Headers */,
+				CCBD05DB1E4136D900D18509 /* PINCacheMacros.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -617,6 +625,7 @@
 				CC0106201E271AB000890935 /* PINCacheObjectSubscripting.h in Headers */,
 				CC0106221E271AB000890935 /* PINMemoryCache.h in Headers */,
 				CC0106211E271AB000890935 /* PINDiskCache.h in Headers */,
+				CCBD05DC1E4136D900D18509 /* PINCacheMacros.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -4,8 +4,9 @@
 
 #import <Foundation/Foundation.h>
 
-#import "PINDiskCache.h"
-#import "PINMemoryCache.h"
+#import <PINCache/PINCacheMacros.h>
+#import <PINCache/PINDiskCache.h>
+#import <PINCache/PINMemoryCache.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,7 +20,7 @@ typedef void (^PINCacheBlock)(PINCache *cache);
 /**
  A callback block which provides the cache, key and object as arguments
  */
-typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullable object);
+typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id _Nullable object);
 
 /**
  A callback block which provides a BOOL value as argument
@@ -44,6 +45,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @warning when using in extension or watch extension, define PIN_APP_EXTENSIONS=1
  */
 
+PIN_SUBCLASSING_RESTRICTED
 @interface PINCache : NSObject <PINCacheObjectSubscripting>
 
 #pragma mark -
@@ -77,7 +79,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  
  @result The shared singleton cache instance.
  */
-+ (instancetype)sharedCache;
+@property (class, strong, readonly) PINCache *sharedCache;
 
 - (instancetype)init NS_UNAVAILABLE;
 
@@ -223,7 +225,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key The key associated with the object.
  @result The object for the specified key.
  */
-- (__nullable id)objectForKey:(NSString *)key;
+- (nullable id)objectForKey:(NSString *)key;
 
 /**
  Stores an object in the cache for the specified key. This method blocks the calling thread until the object has been set.

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -110,6 +110,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
                 return;
             
             if (memoryCacheObject) {
+                // Update file modification date. TODO: Make this a separate method?
                 [strongSelf->_diskCache fileURLForKey:memoryCacheKey block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) { }];
                 [strongSelf->_operationQueue addOperation:^{
                     PINCache *strongSelf = weakSelf;

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -60,13 +60,13 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     return [[NSString alloc] initWithFormat:@"%@.%@.%p", PINCachePrefix, _name, (void *)self];
 }
 
-+ (instancetype)sharedCache
++ (PINCache *)sharedCache
 {
-    static id cache;
+    static PINCache *cache;
     static dispatch_once_t predicate;
     
     dispatch_once(&predicate, ^{
-        cache = [[self alloc] initWithName:PINCacheSharedName];
+        cache = [[PINCache alloc] initWithName:PINCacheSharedName];
     });
     
     return cache;
@@ -110,7 +110,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
                 return;
             
             if (memoryCacheObject) {
-                [strongSelf->_diskCache fileURLForKey:memoryCacheKey block:NULL];
+                [strongSelf->_diskCache fileURLForKey:memoryCacheKey block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) { }];
                 [strongSelf->_operationQueue addOperation:^{
                     PINCache *strongSelf = weakSelf;
                     if (strongSelf)
@@ -252,7 +252,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     return [_memoryCache containsObjectForKey:key] || [_diskCache containsObjectForKey:key];
 }
 
-- (__nullable id)objectForKey:(NSString *)key
+- (nullable id)objectForKey:(NSString *)key
 {
     if (!key)
         return nil;
@@ -263,7 +263,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     
     if (object) {
         // update the access time on disk
-        [_diskCache fileURLForKey:key block:NULL];
+        [_diskCache fileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) { }];
     } else {
         object = [_diskCache objectForKey:key];
         [_memoryCache setObject:object forKey:key];

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -294,7 +294,11 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 - (void)setObject:(id)obj forKeyedSubscript:(NSString *)key
 {
-    [self setObject:obj forKey:key];
+    if (obj == nil) {
+        [self removeObjectForKey:key];
+    } else {
+        [self setObject:obj forKey:key];
+    }
 }
 
 - (void)removeObjectForKey:(NSString *)key

--- a/Source/PINCacheMacros.h
+++ b/Source/PINCacheMacros.h
@@ -1,0 +1,23 @@
+//
+//  PINCacheMacros.h
+//  PINCache
+//
+//  Created by Adlai Holler on 1/31/17.
+//  Copyright © 2017 Pinterest. All rights reserved.
+//
+
+#ifndef PIN_SUBCLASSING_RESTRICTED
+#if defined(__has_attribute) && __has_attribute(objc_subclassing_restricted)
+#define PIN_SUBCLASSING_RESTRICTED __attribute__((objc_subclassing_restricted))
+#else
+#define PIN_SUBCLASSING_RESTRICTED
+#endif // #if defined(__has_attribute) && __has_attribute(objc_subclassing_restricted)
+#endif // #ifndef PIN_SUBCLASSING_RESTRICTED
+
+#ifndef PIN_NOESCAPE
+#if defined(__has_attribute) && __has_attribute(noescape)
+#define PIN_NOESCAPE __attribute__((noescape))
+#else
+#define PIN_NOESCAPE
+#endif // #if defined(__has_attribute) && __has_attribute(noescape)
+#endif // #ifndef PIN_NOESCAPE

--- a/Source/PINCacheObjectSubscripting.h
+++ b/Source/PINCacheObjectSubscripting.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol PINCacheObjectSubscripting <NSObject>
 
 @required
@@ -18,14 +20,16 @@
  @param key The key associated with the object.
  @result The object for the specified key.
  */
-- (id)objectForKeyedSubscript:(NSString *)key;
+- (nullable id)objectForKeyedSubscript:(NSString *)key;
 
 /**
  This method enables using literals on the receiving object, such as `cache[@"key"] = object;`.
  
- @param object An object to be assigned for the key.
+ @param object An object to be assigned for the key. Pass `nil` to remove the existing object for this key.
  @param key A key to associate with the object. This string will be copied.
  */
-- (void)setObject:(id)obj forKeyedSubscript:(NSString *)key;
+- (void)setObject:(nullable id)obj forKeyedSubscript:(NSString *)key;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -4,7 +4,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "PINCacheObjectSubscripting.h"
+#import <PINCache/PINCacheMacros.h>
+#import <PINCache/PINCacheObjectSubscripting.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,12 +20,12 @@ typedef void (^PINDiskCacheBlock)(PINDiskCache *cache);
 /**
  A callback block which provides the cache, key and object as arguments
  */
-typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding>  __nullable object);
+typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding>  _Nullable object);
 
 /**
  A callback block which provides the key and fileURL of the object
  */
-typedef void (^PINDiskCacheFileURLBlock)(NSString *key, NSURL * __nullable fileURL);
+typedef void (^PINDiskCacheFileURLBlock)(NSString *key, NSURL * _Nullable fileURL);
 
 /**
  A callback block which provides a BOOL value as argument
@@ -39,7 +40,7 @@ typedef void (^PINDiskCacheContainsBlock)(BOOL containsObject);
  *
  *  @return Serialized object representation
  */
-typedef NSData* __nonnull(^PINDiskCacheSerializerBlock)(id<NSCoding> object, NSString *key);
+typedef NSData* _Nonnull(^PINDiskCacheSerializerBlock)(id<NSCoding> object, NSString *key);
 
 /**
  *  A block used to deserialize objects
@@ -49,7 +50,7 @@ typedef NSData* __nonnull(^PINDiskCacheSerializerBlock)(id<NSCoding> object, NSS
  *
  *  @return Deserialized object
  */
-typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSString *key);
+typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSString *key);
 
 
 /**
@@ -75,6 +76,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  <ageLimit> will trigger a GCD timer to periodically to trim the cache with <trimToDate:>.
  */
 
+PIN_SUBCLASSING_RESTRICTED
 @interface PINDiskCache : NSObject <PINCacheObjectSubscripting>
 
 
@@ -131,7 +133,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
 /**
  Extension for all cache files on disk. Defaults to no extension. 
  */
-@property (readonly) NSString * __nullable fileExtension;
+@property (nullable, readonly) NSString *fileExtension;
 
 /**
  The writing protection option used when writing a file on disk. This value is used every time an object is set.
@@ -163,34 +165,34 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
 /**
  A block to be executed just before an object is added to the cache. The queue waits during execution.
  */
-@property (copy) PINDiskCacheObjectBlock __nullable willAddObjectBlock;
+@property (nullable, copy) PINDiskCacheObjectBlock willAddObjectBlock;
 
 /**
  A block to be executed just before an object is removed from the cache. The queue waits during execution.
  */
-@property (copy) PINDiskCacheObjectBlock __nullable willRemoveObjectBlock;
+@property (nullable, copy) PINDiskCacheObjectBlock willRemoveObjectBlock;
 
 /**
  A block to be executed just before all objects are removed from the cache as a result of <removeAllObjects:>.
  The queue waits during execution.
  */
-@property (copy) PINDiskCacheBlock __nullable willRemoveAllObjectsBlock;
+@property (nullable, copy) PINDiskCacheBlock willRemoveAllObjectsBlock;
 
 /**
  A block to be executed just after an object is added to the cache. The queue waits during execution.
  */
-@property (copy) PINDiskCacheObjectBlock __nullable didAddObjectBlock;
+@property (nullable, copy) PINDiskCacheObjectBlock didAddObjectBlock;
 
 /**
  A block to be executed just after an object is removed from the cache. The queue waits during execution.
  */
-@property (copy) PINDiskCacheObjectBlock __nullable didRemoveObjectBlock;
+@property (nullable, copy) PINDiskCacheObjectBlock didRemoveObjectBlock;
 
 /**
  A block to be executed just after all objects are removed from the cache as a result of <removeAllObjects:>.
  The queue waits during execution.
  */
-@property (copy) PINDiskCacheBlock __nullable didRemoveAllObjectsBlock;
+@property (nullable, copy) PINDiskCacheBlock didRemoveAllObjectsBlock;
 
 #pragma mark -
 /// @name Initialization
@@ -200,7 +202,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  
  @result The shared singleton cache instance.
  */
-+ (instancetype)sharedCache;
+@property (class, readonly, strong) PINDiskCache *sharedCache;
 
 /**
  Empties the trash with `DISPATCH_QUEUE_PRIORITY_BACKGROUND`. Does not use lock.
@@ -276,7 +278,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  
  @param block A block to be executed when a lock is available.
  */
-- (void)lockFileAccessWhileExecutingBlock:(nullable PINDiskCacheBlock)block;
+- (void)lockFileAccessWhileExecutingBlock:(PINDiskCacheBlock)block;
 
 /**
  This method determines whether an object is present for the given key in the cache. This method returns immediately
@@ -296,7 +298,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  @param key The key associated with the requested object.
  @param block A block to be executed serially when the object is available.
  */
-- (void)objectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key block:(PINDiskCacheObjectBlock)block;
 
 /**
  Retrieves the fileURL for the specified key without actually reading the data from disk. This method
@@ -313,7 +315,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  @param key The key associated with the requested object.
  @param block A block to be executed serially when the file URL is available.
  */
-- (void)fileURLForKey:(NSString *)key block:(nullable PINDiskCacheFileURLBlock)block;
+- (void)fileURLForKey:(NSString *)key block:(PINDiskCacheFileURLBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
@@ -397,7 +399,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  
  @param block A block to be executed when a lock is available.
  */
-- (void)synchronouslyLockFileAccessWhileExecutingBlock:(nullable PINDiskCacheBlock)block;
+- (void)synchronouslyLockFileAccessWhileExecutingBlock:(PIN_NOESCAPE PINDiskCacheBlock)block;
 
 /**
  This method determines whether an object is present for the given key in the cache.
@@ -416,7 +418,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  @param key The key associated with the object.
  @result The object for the specified key.
  */
-- (__nullable id <NSCoding>)objectForKey:(NSString *)key;
+- (nullable id <NSCoding>)objectForKey:(NSString *)key;
 
 /**
  Retrieves the file URL for the specified key. This method blocks the calling thread until the
@@ -489,7 +491,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  lock is held.
  
  */
-- (void)enumerateObjectsWithBlock:(nullable PINDiskCacheFileURLBlock)block;
+- (void)enumerateObjectsWithBlock:(PIN_NOESCAPE PINDiskCacheFileURLBlock)block;
 
 @end
 

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -855,7 +855,11 @@ static NSURL *_sharedTrashURL;
 
 - (void)setObject:(id)object forKeyedSubscript:(NSString *)key
 {
-    [self setObject:object forKey:key];
+    if (object == nil) {
+        [self removeObjectForKey:key];
+    } else {
+        [self setObject:object forKey:key];
+    }
 }
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key fileURL:(NSURL **)outFileURL

--- a/Source/PINMemoryCache.h
+++ b/Source/PINMemoryCache.h
@@ -4,7 +4,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "PINCacheObjectSubscripting.h"
+#import <PINCache/PINCacheMacros.h>
+#import <PINCache/PINCacheObjectSubscripting.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,7 +20,7 @@ typedef void (^PINMemoryCacheBlock)(PINMemoryCache *cache);
 /**
  A callback block which provides the cache, key and object as arguments
  */
-typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, id __nullable object);
+typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, id _Nullable object);
 
 /**
  A callback block which provides a BOOL value as argument
@@ -44,6 +45,7 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  a memory cache backed by a disk cache.
  */
 
+PIN_SUBCLASSING_RESTRICTED
 @interface PINMemoryCache : NSObject <PINCacheObjectSubscripting>
 
 #pragma mark -
@@ -96,54 +98,54 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheObjectBlock __nullable willAddObjectBlock;
+@property (nullable, copy) PINMemoryCacheObjectBlock willAddObjectBlock;
 
 /**
  A block to be executed just before an object is removed from the cache. This block will be excuted
  within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheObjectBlock __nullable willRemoveObjectBlock;
+@property (nullable, copy) PINMemoryCacheObjectBlock willRemoveObjectBlock;
 
 /**
  A block to be executed just before all objects are removed from the cache as a result of <removeAllObjects:>.
  This block will be excuted within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheBlock __nullable willRemoveAllObjectsBlock;
+@property (nullable, copy) PINMemoryCacheBlock willRemoveAllObjectsBlock;
 
 /**
  A block to be executed just after an object is added to the cache. This block will be excuted within
  a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheObjectBlock __nullable didAddObjectBlock;
+@property (nullable, copy) PINMemoryCacheObjectBlock didAddObjectBlock;
 
 /**
  A block to be executed just after an object is removed from the cache. This block will be excuted
  within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheObjectBlock __nullable didRemoveObjectBlock;
+@property (nullable, copy) PINMemoryCacheObjectBlock didRemoveObjectBlock;
 
 /**
  A block to be executed just after all objects are removed from the cache as a result of <removeAllObjects:>.
  This block will be excuted within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheBlock __nullable didRemoveAllObjectsBlock;
+@property (nullable, copy) PINMemoryCacheBlock didRemoveAllObjectsBlock;
 
 /**
  A block to be executed upon receiving a memory warning (iOS only) potentially in parallel with other blocks on the <queue>.
  This block will be executed regardless of the value of <removeAllObjectsOnMemoryWarning>. Defaults to `nil`.
  */
-@property (copy) PINMemoryCacheBlock __nullable didReceiveMemoryWarningBlock;
+@property (nullable, copy) PINMemoryCacheBlock didReceiveMemoryWarningBlock;
 
 /**
  A block to be executed when the app enters the background (iOS only) potentially in parallel with other blocks on the <concurrentQueue>.
  This block will be executed regardless of the value of <removeAllObjectsOnEnteringBackground>. Defaults to `nil`.
  */
-@property (copy) PINMemoryCacheBlock __nullable didEnterBackgroundBlock;
+@property (nullable, copy) PINMemoryCacheBlock didEnterBackgroundBlock;
 
 #pragma mark -
 /// @name Shared Cache
@@ -153,7 +155,7 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  
  @result The shared singleton cache instance.
  */
-+ (instancetype)sharedCache;
+@property (class, strong, readonly) PINMemoryCache *sharedCache;
 
 - (instancetype)initWithOperationQueue:(PINOperationQueue *)operationQueue NS_DESIGNATED_INITIALIZER;
 
@@ -178,7 +180,7 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  @param key The key associated with the requested object.
  @param block A block to be executed concurrently when the object is available.
  */
-- (void)objectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block;
+- (void)objectForKey:(NSString *)key block:(PINMemoryCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
@@ -279,7 +281,7 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  @param key The key associated with the object.
  @result The object for the specified key.
  */
-- (__nullable id)objectForKey:(nullable NSString *)key;
+- (nullable id)objectForKey:(NSString *)key;
 
 /**
  Stores an object in the cache for the specified key. This method blocks the calling thread until the object
@@ -300,7 +302,7 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  @param key A key to associate with the object. This string will be copied.
  @param cost An amount to add to the <totalCost>.
  */
-- (void)setObject:(nullable id)object forKey:(nullable NSString *)key withCost:(NSUInteger)cost;
+- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost;
 
 /**
  Removes the object for the specified key. This method blocks the calling thread until the object
@@ -308,7 +310,7 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  
  @param key The key associated with the object to be removed.
  */
-- (void)removeObjectForKey:(nullable NSString *)key;
+- (void)removeObjectForKey:(NSString *)key;
 
 /**
  Removes all objects from the cache that have not been used since the specified date.
@@ -350,7 +352,7 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  Instead use the asynchronous version, <enumerateObjectsWithBlock:completionBlock:>.
  
  */
-- (void)enumerateObjectsWithBlock:(nullable PINMemoryCacheObjectBlock)block;
+- (void)enumerateObjectsWithBlock:(PIN_NOESCAPE PINMemoryCacheObjectBlock)block;
 
 @end
 

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -96,13 +96,13 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     return self;
 }
 
-+ (instancetype)sharedCache
++ (PINMemoryCache *)sharedCache
 {
-    static id cache;
+    static PINMemoryCache *cache;
     static dispatch_once_t predicate;
 
     dispatch_once(&predicate, ^{
-        cache = [[self alloc] init];
+        cache = [[PINMemoryCache alloc] init];
     });
 
     return cache;
@@ -290,14 +290,16 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 
 - (void)objectForKey:(NSString *)key block:(PINMemoryCacheObjectBlock)block
 {
+    if (!block) {
+        return;
+    }
     __weak PINMemoryCache *weakSelf = self;
     
     [self.operationQueue addOperation:^{
         PINMemoryCache *strongSelf = weakSelf;
         id object = [strongSelf objectForKey:key];
-        
-        if (block)
-            block(strongSelf, key, object);
+
+        block(strongSelf, key, object);
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
@@ -410,7 +412,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     return containsObject;
 }
 
-- (__nullable id)objectForKey:(NSString *)key
+- (nullable id)objectForKey:(NSString *)key
 {
     if (!key)
         return nil;

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -447,7 +447,11 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 
 - (void)setObject:(id)object forKeyedSubscript:(NSString *)key
 {
-    [self setObject:object forKey:key];
+    if (object == nil) {
+        [self removeObjectForKey:key];
+    } else {
+        [self setObject:object forKey:key];
+    }
 }
 
 - (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -758,7 +758,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", (unsigned long)expectedObjCount);
 
     objCount = 0;
-    [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache *cache, NSString *key, id __nullable object) {
+    [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache *cache, NSString *key, id _Nullable object) {
       objCount++;
     }];
 


### PR DESCRIPTION
Lately I've learned some fancy new Objective-C tricks!

- Set project indentation to use spaces.
- Prohibit subclassing of all three main classes. They're not suitable for subclassing, and this could possibly mean static dispatch one day. **Breaking API**
- Replace `__nullable` and `__nonnull` (Xcode 6 names) with `nullable` or `_Nullable` (Xcode 7 names).
- Mark more arguments nonnull. We may handle `nil` in production but nullability also communicates how something should be used. For example, `setObject:forKey:` now requires the object and key because it just doesn't make sense to pass `nil` here. **Breaking API for Swift**
- Replace `+(instancetype)sharedThing` with `@property (class, strong, readonly) PINThing *sharedThing`. **Breaking API for Swift**
- Mark blocks as `noescape` where appropriate. **API improvement for Swift**