### PR TITLE
Introduce PINCaching protocol

### DIFF
--- a/PINCache.xcodeproj/project.pbxproj
+++ b/PINCache.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6928EED31E4160EE00B5D975 /* PINCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 6928EED21E4160EE00B5D975 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6928EED41E4160FE00B5D975 /* PINCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 6928EED21E4160EE00B5D975 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6928EED51E41610700B5D975 /* PINCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 6928EED21E4160EE00B5D975 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CC0105DF1E271A5C00890935 /* PINCache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0105B11E271A1600890935 /* PINCache.framework */; };
 		CC0105EE1E271A6400890935 /* PINCache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0105C11E271A4000890935 /* PINCache.framework */; };
 		CC0105FD1E271A7300890935 /* PINCache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0105CE1E271A4900890935 /* PINCache.framework */; };
@@ -102,6 +105,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6928EED21E4160EE00B5D975 /* PINCaching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PINCaching.h; sourceTree = "<group>"; };
 		CC0105B11E271A1600890935 /* PINCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PINCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC0105C11E271A4000890935 /* PINCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PINCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC0105CE1E271A4900890935 /* PINCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PINCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -264,6 +268,7 @@
 			isa = PBXGroup;
 			children = (
 				CC0106441E281B0E00890935 /* Info.plist */,
+				6928EED21E4160EE00B5D975 /* PINCaching.h */,
 				CC0106051E271A9000890935 /* PINCache.h */,
 				CC0106061E271A9000890935 /* PINCache.m */,
 				CC0106071E271A9000890935 /* PINCacheObjectSubscripting.h */,
@@ -591,6 +596,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6928EED31E4160EE00B5D975 /* PINCaching.h in Headers */,
 				CC0106171E271AAF00890935 /* PINCache.h in Headers */,
 				CC0106181E271AAF00890935 /* PINCacheObjectSubscripting.h in Headers */,
 				CC01061A1E271AAF00890935 /* PINMemoryCache.h in Headers */,
@@ -602,6 +608,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6928EED41E4160FE00B5D975 /* PINCaching.h in Headers */,
 				CC01061B1E271AB000890935 /* PINCache.h in Headers */,
 				CC01061C1E271AB000890935 /* PINCacheObjectSubscripting.h in Headers */,
 				CC01061E1E271AB000890935 /* PINMemoryCache.h in Headers */,
@@ -613,6 +620,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6928EED51E41610700B5D975 /* PINCaching.h in Headers */,
 				CC01061F1E271AB000890935 /* PINCache.h in Headers */,
 				CC0106201E271AB000890935 /* PINCacheObjectSubscripting.h in Headers */,
 				CC0106221E271AB000890935 /* PINMemoryCache.h in Headers */,

--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -113,4 +113,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface PINCache (Deprecated)
+- (void)containsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block __attribute__((deprecated));
+- (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block __attribute__((deprecated));
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block __attribute__((deprecated));
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block __attribute__((deprecated));
+- (void)removeObjectForKey:(NSString *)key block:(nullable PINCacheObjectBlock)block __attribute__((deprecated));
+- (void)trimToDate:(NSDate *)date block:(nullable PINCacheBlock)block __attribute__((deprecated));
+- (void)removeAllObjects:(nullable PINCacheBlock)block __attribute__((deprecated));
+@end
+
 NS_ASSUME_NONNULL_END

--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -4,27 +4,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import "PINCaching.h"
 #import "PINDiskCache.h"
 #import "PINMemoryCache.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class PINCache;
-
-/**
- A callback block which provides only the cache as an argument
- */
-typedef void (^PINCacheBlock)(PINCache *cache);
-
-/**
- A callback block which provides the cache, key and object as arguments
- */
-typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullable object);
-
-/**
- A callback block which provides a BOOL value as argument
- */
-typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
 
 
 /**
@@ -44,15 +30,10 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @warning when using in extension or watch extension, define PIN_APP_EXTENSIONS=1
  */
 
-@interface PINCache : NSObject <PINCacheObjectSubscripting>
+@interface PINCache : NSObject <PINCaching, PINCacheObjectSubscripting>
 
 #pragma mark -
 /// @name Core
-
-/**
- The name of this cache, used to create the <diskCache> and also appearing in stack traces.
- */
-@property (readonly) NSString *name;
 
 /**
  Synchronously retrieves the total byte count of the <diskCache> on the shared disk queue.
@@ -69,7 +50,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  */
 @property (readonly) PINMemoryCache *memoryCache;
 
-#pragma mark -
+#pragma mark - Lifecycle
 /// @name Initialization
 
 /**
@@ -129,146 +110,6 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @result A new cache with the specified name.
  */
 - (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer fileExtension:(nullable NSString *)fileExtension NS_DESIGNATED_INITIALIZER;
-
-
-#pragma mark -
-/// @name Asynchronous Methods
-
-/**
- This method determines whether an object is present for the given key in the cache. This method returns immediately
- and executes the passed block after the object is available, potentially in parallel with other blocks on the
- <concurrentQueue>.
- 
- @see containsObjectForKey:
- @param key The key associated with the object.
- @param block A block to be executed concurrently after the containment check happened
- */
-- (void)containsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block;
-
-/**
- Retrieves the object for the specified key. This method returns immediately and executes the passed
- block after the object is available, potentially in parallel with other blocks on the <concurrentQueue>.
- 
- @param key The key associated with the requested object.
- @param block A block to be executed concurrently when the object is available.
- */
-- (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block;
-
-/**
- Stores an object in the cache for the specified key. This method returns immediately and executes the
- passed block after the object has been stored, potentially in parallel with other blocks on the <concurrentQueue>.
- 
- @param object An object to store in the cache.
- @param key A key to associate with the object. This string will be copied.
- @param block A block to be executed concurrently after the object has been stored, or nil.
- */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
-
-/**
- Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
- to go over the <memoryCache.costLimit> the cache is trimmed (oldest objects first). This method returns immediately
- and executes the passed block after the object has been stored, potentially in parallel with other blocks
- on the <concurrentQueue>.
- 
- @param object An object to store in the cache.
- @param key A key to associate with the object. This string will be copied.
- @param cost An amount to add to the <memoryCache.totalCost>.
- @param block A block to be executed concurrently after the object has been stored, or nil.
- */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
-
-/**
- Removes the object for the specified key. This method returns immediately and executes the passed
- block after the object has been removed, potentially in parallel with other blocks on the <concurrentQueue>.
- 
- @param key The key associated with the object to be removed.
- @param block A block to be executed concurrently after the object has been removed, or nil.
- */
-- (void)removeObjectForKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
-
-/**
- Removes all objects from the cache that have not been used since the specified date. This method returns immediately and
- executes the passed block after the cache has been trimmed, potentially in parallel with other blocks on the <concurrentQueue>.
- 
- @param date Objects that haven't been accessed since this date are removed from the cache.
- @param block A block to be executed concurrently after the cache has been trimmed, or nil.
- */
-- (void)trimToDate:(NSDate *)date block:(nullable PINCacheBlock)block;
-
-/**
- Removes all objects from the cache.This method returns immediately and executes the passed block after the
- cache has been cleared, potentially in parallel with other blocks on the <concurrentQueue>.
- 
- @param block A block to be executed concurrently after the cache has been cleared, or nil.
- */
-- (void)removeAllObjects:(nullable PINCacheBlock)block;
-
-#pragma mark -
-/// @name Synchronous Methods
-
-/**
- This method determines whether an object is present for the given key in the cache.
- 
- @see containsObjectForKey:block:
- @param key The key associated with the object.
- @result YES if an object is present for the given key in the cache, otherwise NO.
- */
-- (BOOL)containsObjectForKey:(NSString *)key;
-
-/**
- Retrieves the object for the specified key. This method blocks the calling thread until the object is available.
- Uses a lock to achieve synchronicity on the disk cache.
- 
- @see objectForKey:block:
- @param key The key associated with the object.
- @result The object for the specified key.
- */
-- (__nullable id)objectForKey:(NSString *)key;
-
-/**
- Stores an object in the cache for the specified key. This method blocks the calling thread until the object has been set.
- Uses a lock to achieve synchronicity on the disk cache.
- 
- @see setObject:forKey:block:
- @param object An object to store in the cache.
- @param key A key to associate with the object. This string will be copied.
- */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
-
-/**
- Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
- to go over the <memoryCache.costLimit> the cache is trimmed (oldest objects first). This method blocks the calling thread
- until the object has been stored.
- 
- @param object An object to store in the cache.
- @param key A key to associate with the object. This string will be copied.
- @param cost An amount to add to the <memoryCache.totalCost>.
- */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost;
-
-/**
- Removes the object for the specified key. This method blocks the calling thread until the object
- has been removed.
- Uses a lock to achieve synchronicity on the disk cache.
- 
- @param key The key associated with the object to be removed.
- */
-- (void)removeObjectForKey:(NSString *)key;
-
-/**
- Removes all objects from the cache that have not been used since the specified date.
- This method blocks the calling thread until the cache has been trimmed.
- Uses a lock to achieve synchronicity on the disk cache.
- 
- @param date Objects that haven't been accessed since this date are removed from the cache.
- */
-- (void)trimToDate:(NSDate *)date;
-
-/**
- Removes all objects from the cache. This method blocks the calling thread until the cache has been cleared.
- Uses a lock to achieve synchronicity on the disk cache.
- */
-- (void)removeAllObjects;
 
 @end
 

--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -4,9 +4,9 @@
 
 #import <Foundation/Foundation.h>
 
-#import "PINCaching.h"
-#import "PINDiskCache.h"
-#import "PINMemoryCache.h"
+#import <PINCache/PINCaching.h>
+#import <PINCache/PINDiskCache.h>
+#import <PINCache/PINMemoryCache.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -74,7 +74,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 #pragma mark - Public Asynchronous Methods -
 
-- (void)asyncContainsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block
+- (void)containsObjectForKeyAsync:(NSString *)key block:(PINCacheObjectContainmentBlock)block
 {
     if (!key || !block) {
         return;
@@ -93,7 +93,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshadow"
 
-- (void)asyncObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)objectForKeyAsync:(NSString *)key block:(PINCacheObjectBlock)block
 {
     if (!key || !block)
         return;
@@ -104,25 +104,25 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
         PINCache *strongSelf = weakSelf;
         if (!strongSelf)
             return;
-        [strongSelf->_memoryCache asyncObjectForKey:key block:^(PINMemoryCache *memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
+        [strongSelf->_memoryCache objectForKeyAsync:key block:^(PINMemoryCache *memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
             PINCache *strongSelf = weakSelf;
             if (!strongSelf)
                 return;
             
             if (memoryCacheObject) {
-                [strongSelf->_diskCache asyncFileURLForKey:memoryCacheKey block:NULL];
+                [strongSelf->_diskCache fileURLForKeyAsync:memoryCacheKey block:NULL];
                 [strongSelf->_operationQueue addOperation:^{
                     PINCache *strongSelf = weakSelf;
                     if (strongSelf)
                         block(strongSelf, memoryCacheKey, memoryCacheObject);
                 }];
             } else {
-                [strongSelf->_diskCache asyncObjectForKey:memoryCacheKey block:^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> diskCacheObject) {
+                [strongSelf->_diskCache objectForKeyAsync:memoryCacheKey block:^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> diskCacheObject) {
                     PINCache *strongSelf = weakSelf;
                     if (!strongSelf)
                         return;
                     
-                    [strongSelf->_memoryCache asyncSetObject:diskCacheObject forKey:diskCacheKey block:nil];
+                    [strongSelf->_memoryCache setObjectAsync:diskCacheObject forKey:diskCacheKey block:nil];
                     
                     [strongSelf->_operationQueue addOperation:^{
                         PINCache *strongSelf = weakSelf;
@@ -137,12 +137,12 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 #pragma clang diagnostic pop
 
-- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
-    [self asyncSetObject:object forKey:key withCost:0 block:block];
+    [self setObjectAsync:object forKey:key withCost:0 block:block];
 }
 
-- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
+- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
 {
     if (!key || !object)
         return;
@@ -165,7 +165,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [group start];
 }
 
-- (void)asyncRemoveObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)removeObjectForKeyAsync:(NSString *)key block:(PINCacheObjectBlock)block
 {
     if (!key)
         return;
@@ -188,7 +188,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [group start];
 }
 
-- (void)asyncRemoveAllObjects:(PINCacheBlock)block
+- (void)removeAllObjectsAsync:(PINCacheBlock)block
 {
     PINOperationGroup *group = [PINOperationGroup asyncOperationGroupWithQueue:_operationQueue];
     
@@ -208,7 +208,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [group start];
 }
 
-- (void)asyncTrimToDate:(NSDate *)date block:(PINCacheBlock)block
+- (void)trimToDateAsync:(NSDate *)date block:(PINCacheBlock)block
 {
     if (!date)
         return;
@@ -263,7 +263,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     
     if (object) {
         // update the access time on disk
-        [_diskCache asyncFileURLForKey:key block:NULL];
+        [_diskCache fileURLForKeyAsync:key block:NULL];
     } else {
         object = [_diskCache objectForKey:key];
         [_memoryCache setObject:object forKey:key];
@@ -330,37 +330,37 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 - (void)containsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block
 {
-    [self asyncContainsObjectForKey:key block:block];
+    [self containsObjectForKeyAsync:key block:block];
 }
 
 - (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
-    [self asyncObjectForKey:key block:block];
+    [self objectForKeyAsync:key block:block];
 }
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block
 {
-    [self asyncSetObject:object forKey:key block:block];
+    [self setObjectAsync:object forKey:key block:block];
 }
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block
 {
-    [self asyncSetObject:object forKey:key withCost:cost block:block];
+    [self setObjectAsync:object forKey:key withCost:cost block:block];
 }
 
 - (void)removeObjectForKey:(NSString *)key block:(nullable PINCacheObjectBlock)block
 {
-    [self asyncRemoveObjectForKey:key block:block];
+    [self removeObjectForKeyAsync:key block:block];
 }
 
 - (void)trimToDate:(NSDate *)date block:(nullable PINCacheBlock)block
 {
-    [self asyncTrimToDate:date block:block];
+    [self trimToDateAsync:date block:block];
 }
 
 - (void)removeAllObjects:(nullable PINCacheBlock)block
 {
-    [self asyncRemoveAllObjects:block];
+    [self removeAllObjectsAsync:block];
 }
 
 @end

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -252,7 +252,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     return [_memoryCache containsObjectForKey:key] || [_diskCache containsObjectForKey:key];
 }
 
-- (__nullable id)objectForKey:(NSString *)key
+- (nullable id)objectForKey:(NSString *)key
 {
     if (!key)
         return nil;
@@ -286,14 +286,18 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [_diskCache setObject:object forKey:key];
 }
 
-- (id)objectForKeyedSubscript:(NSString *)key
+- (nullable id)objectForKeyedSubscript:(NSString *)key
 {
     return [self objectForKey:key];
 }
 
-- (void)setObject:(id)obj forKeyedSubscript:(NSString *)key
+- (void)setObject:(nullable id)obj forKeyedSubscript:(NSString *)key
 {
-    [self setObject:obj forKey:key];
+    if (obj == nil) {
+        [self removeObjectForKey:key];
+    } else {
+        [self setObject:obj forKey:key];
+    }
 }
 
 - (void)removeObjectForKey:(NSString *)key

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -74,7 +74,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 #pragma mark - Public Asynchronous Methods -
 
-- (void)containsObjectForKeyAsync:(NSString *)key block:(PINCacheObjectContainmentBlock)block
+- (void)containsObjectForKeyAsync:(NSString *)key completion:(PINCacheObjectContainmentBlock)block
 {
     if (!key || !block) {
         return;
@@ -93,7 +93,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshadow"
 
-- (void)objectForKeyAsync:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)objectForKeyAsync:(NSString *)key completion:(PINCacheObjectBlock)block
 {
     if (!key || !block)
         return;
@@ -104,25 +104,25 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
         PINCache *strongSelf = weakSelf;
         if (!strongSelf)
             return;
-        [strongSelf->_memoryCache objectForKeyAsync:key block:^(PINMemoryCache *memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
+        [strongSelf->_memoryCache objectForKeyAsync:key completion:^(PINMemoryCache *memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
             PINCache *strongSelf = weakSelf;
             if (!strongSelf)
                 return;
             
             if (memoryCacheObject) {
-                [strongSelf->_diskCache fileURLForKeyAsync:memoryCacheKey block:NULL];
+                [strongSelf->_diskCache fileURLForKeyAsync:memoryCacheKey completion:NULL];
                 [strongSelf->_operationQueue addOperation:^{
                     PINCache *strongSelf = weakSelf;
                     if (strongSelf)
                         block(strongSelf, memoryCacheKey, memoryCacheObject);
                 }];
             } else {
-                [strongSelf->_diskCache objectForKeyAsync:memoryCacheKey block:^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> diskCacheObject) {
+                [strongSelf->_diskCache objectForKeyAsync:memoryCacheKey completion:^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> diskCacheObject) {
                     PINCache *strongSelf = weakSelf;
                     if (!strongSelf)
                         return;
                     
-                    [strongSelf->_memoryCache setObjectAsync:diskCacheObject forKey:diskCacheKey block:nil];
+                    [strongSelf->_memoryCache setObjectAsync:diskCacheObject forKey:diskCacheKey completion:nil];
                     
                     [strongSelf->_operationQueue addOperation:^{
                         PINCache *strongSelf = weakSelf;
@@ -137,12 +137,12 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 #pragma clang diagnostic pop
 
-- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key completion:(PINCacheObjectBlock)block
 {
-    [self setObjectAsync:object forKey:key withCost:0 block:block];
+    [self setObjectAsync:object forKey:key withCost:0 completion:block];
 }
 
-- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
+- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost completion:(PINCacheObjectBlock)block
 {
     if (!key || !object)
         return;
@@ -165,7 +165,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [group start];
 }
 
-- (void)removeObjectForKeyAsync:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)removeObjectForKeyAsync:(NSString *)key completion:(PINCacheObjectBlock)block
 {
     if (!key)
         return;
@@ -208,7 +208,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [group start];
 }
 
-- (void)trimToDateAsync:(NSDate *)date block:(PINCacheBlock)block
+- (void)trimToDateAsync:(NSDate *)date completion:(PINCacheBlock)block
 {
     if (!date)
         return;
@@ -263,7 +263,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     
     if (object) {
         // update the access time on disk
-        [_diskCache fileURLForKeyAsync:key block:NULL];
+        [_diskCache fileURLForKeyAsync:key completion:NULL];
     } else {
         object = [_diskCache objectForKey:key];
         [_memoryCache setObject:object forKey:key];
@@ -330,32 +330,32 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 - (void)containsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block
 {
-    [self containsObjectForKeyAsync:key block:block];
+    [self containsObjectForKeyAsync:key completion:block];
 }
 
 - (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
-    [self objectForKeyAsync:key block:block];
+    [self objectForKeyAsync:key completion:block];
 }
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block
 {
-    [self setObjectAsync:object forKey:key block:block];
+    [self setObjectAsync:object forKey:key completion:block];
 }
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block
 {
-    [self setObjectAsync:object forKey:key withCost:cost block:block];
+    [self setObjectAsync:object forKey:key withCost:cost completion:block];
 }
 
 - (void)removeObjectForKey:(NSString *)key block:(nullable PINCacheObjectBlock)block
 {
-    [self removeObjectForKeyAsync:key block:block];
+    [self removeObjectForKeyAsync:key completion:block];
 }
 
 - (void)trimToDate:(NSDate *)date block:(nullable PINCacheBlock)block
 {
-    [self trimToDateAsync:date block:block];
+    [self trimToDateAsync:date completion:block];
 }
 
 - (void)removeAllObjects:(nullable PINCacheBlock)block

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -10,6 +10,7 @@ static NSString * const PINCachePrefix = @"com.pinterest.PINCache";
 static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 @interface PINCache ()
+@property (copy, nonatomic) NSString *name;
 @property (strong, nonatomic) PINOperationQueue *operationQueue;
 @end
 

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -321,3 +321,42 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 }
 
 @end
+
+@implementation PINCache (Deprecated)
+
+- (void)containsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block
+{
+    [self asyncContainsObjectForKey:key block:block];
+}
+
+- (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block
+{
+    [self asyncObjectForKey:key block:block];
+}
+
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block
+{
+    [self asyncSetObject:object forKey:key block:block];
+}
+
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block
+{
+    [self asyncSetObject:object forKey:key withCost:cost block:block];
+}
+
+- (void)removeObjectForKey:(NSString *)key block:(nullable PINCacheObjectBlock)block
+{
+    [self asyncRemoveObjectForKey:key block:block];
+}
+
+- (void)trimToDate:(NSDate *)date block:(nullable PINCacheBlock)block
+{
+    [self asyncTrimToDate:date block:block];
+}
+
+- (void)removeAllObjects:(nullable PINCacheBlock)block
+{
+    [self asyncRemoveAllObjects:block];
+}
+
+@end

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -74,7 +74,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 #pragma mark - Public Asynchronous Methods -
 
-- (void)containsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block
+- (void)asyncContainsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block
 {
     if (!key || !block) {
         return;
@@ -93,7 +93,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshadow"
 
-- (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)asyncObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
     if (!key || !block)
         return;
@@ -104,25 +104,25 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
         PINCache *strongSelf = weakSelf;
         if (!strongSelf)
             return;
-        [strongSelf->_memoryCache objectForKey:key block:^(PINMemoryCache *memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
+        [strongSelf->_memoryCache asyncObjectForKey:key block:^(PINMemoryCache *memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
             PINCache *strongSelf = weakSelf;
             if (!strongSelf)
                 return;
             
             if (memoryCacheObject) {
-                [strongSelf->_diskCache fileURLForKey:memoryCacheKey block:NULL];
+                [strongSelf->_diskCache asyncFileURLForKey:memoryCacheKey block:NULL];
                 [strongSelf->_operationQueue addOperation:^{
                     PINCache *strongSelf = weakSelf;
                     if (strongSelf)
                         block(strongSelf, memoryCacheKey, memoryCacheObject);
                 }];
             } else {
-                [strongSelf->_diskCache objectForKey:memoryCacheKey block:^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> diskCacheObject) {
+                [strongSelf->_diskCache asyncObjectForKey:memoryCacheKey block:^(PINDiskCache *diskCache, NSString *diskCacheKey, id <NSCoding> diskCacheObject) {
                     PINCache *strongSelf = weakSelf;
                     if (!strongSelf)
                         return;
                     
-                    [strongSelf->_memoryCache setObject:diskCacheObject forKey:diskCacheKey block:nil];
+                    [strongSelf->_memoryCache asyncSetObject:diskCacheObject forKey:diskCacheKey block:nil];
                     
                     [strongSelf->_operationQueue addOperation:^{
                         PINCache *strongSelf = weakSelf;
@@ -137,12 +137,12 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 #pragma clang diagnostic pop
 
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
-    [self setObject:object forKey:key withCost:0 block:block];
+    [self asyncSetObject:object forKey:key withCost:0 block:block];
 }
 
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
+- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
 {
     if (!key || !object)
         return;
@@ -165,7 +165,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [group start];
 }
 
-- (void)removeObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)asyncRemoveObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
     if (!key)
         return;
@@ -188,7 +188,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [group start];
 }
 
-- (void)removeAllObjects:(PINCacheBlock)block
+- (void)asyncRemoveAllObjects:(PINCacheBlock)block
 {
     PINOperationGroup *group = [PINOperationGroup asyncOperationGroupWithQueue:_operationQueue];
     
@@ -208,7 +208,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [group start];
 }
 
-- (void)trimToDate:(NSDate *)date block:(PINCacheBlock)block
+- (void)asyncTrimToDate:(NSDate *)date block:(PINCacheBlock)block
 {
     if (!date)
         return;
@@ -263,7 +263,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     
     if (object) {
         // update the access time on disk
-        [_diskCache fileURLForKey:key block:NULL];
+        [_diskCache asyncFileURLForKey:key block:NULL];
     } else {
         object = [_diskCache objectForKey:key];
         [_memoryCache setObject:object forKey:key];

--- a/Source/PINCaching.h
+++ b/Source/PINCaching.h
@@ -118,7 +118,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
 /**
  This method determines whether an object is present for the given key in the cache.
  
- @see containsObjectForKey:block:
+ @see containsObjectForKeyAsync:completion:
  @param key The key associated with the object.
  @result YES if an object is present for the given key in the cache, otherwise NO.
  */
@@ -128,7 +128,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  Retrieves the object for the specified key. This method blocks the calling thread until the object is available.
  Uses a lock to achieve synchronicity on the disk cache.
  
- @see objectForKey:block:
+ @see objectForKeyAsync:completion:
  @param key The key associated with the object.
  @result The object for the specified key.
  */
@@ -138,7 +138,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  Stores an object in the cache for the specified key. This method blocks the calling thread until the object has been set.
  Uses a lock to achieve synchronicity on the disk cache.
  
- @see setObject:forKey:block:
+ @see setObjectAsync:forKey:completion:
  @param object An object to store in the cache.
  @param key A key to associate with the object. This string will be copied.
  */
@@ -160,6 +160,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  has been removed.
  Uses a lock to achieve synchronicity on the disk cache.
  
+ @see removeObjectForKeyAsync:completion:
  @param key The key associated with the object to be removed.
  */
 - (void)removeObjectForKey:(NSString *)key;
@@ -169,6 +170,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  This method blocks the calling thread until the cache has been trimmed.
  Uses a lock to achieve synchronicity on the disk cache.
  
+ @see trimToDateAsync:completion:
  @param date Objects that haven't been accessed since this date are removed from the cache.
  */
 - (void)trimToDate:(NSDate *)date;
@@ -176,6 +178,8 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
 /**
  Removes all objects from the cache. This method blocks the calling thread until the cache has been cleared.
  Uses a lock to achieve synchronicity on the disk cache.
+ 
+ @see removeAllObjectsAsync:
  */
 - (void)removeAllObjects;
 

--- a/Source/PINCaching.h
+++ b/Source/PINCaching.h
@@ -22,7 +22,7 @@ typedef void (^PINCacheBlock)(id<PINCaching> cache);
 /**
  A callback block which provides the cache, key and object as arguments
  */
-typedef void (^PINCacheObjectBlock)(id<PINCaching> cache, NSString *key, id __nullable object);
+typedef void (^PINCacheObjectBlock)(id<PINCaching> cache, NSString *key, id _Nullable object);
 
 /**
  A callback block which provides a BOOL value as argument
@@ -70,7 +70,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key A key to associate with the object. This string will be copied.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
+- (void)asyncSetObject:(id)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
@@ -83,7 +83,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param cost An amount to add to the <memoryCache.totalCost>.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
+- (void)asyncSetObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed
@@ -142,7 +142,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param object An object to store in the cache.
  @param key A key to associate with the object. This string will be copied.
  */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
+- (void)setObject:(nullable id)object forKey:(NSString *)key;
 
 /**
  Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
@@ -153,7 +153,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key A key to associate with the object. This string will be copied.
  @param cost An amount to add to the <memoryCache.totalCost>.
  */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost;
+- (void)setObject:(nullable id)object forKey:(NSString *)key withCost:(NSUInteger)cost;
 
 /**
  Removes the object for the specified key. This method blocks the calling thread until the object

--- a/Source/PINCaching.h
+++ b/Source/PINCaching.h
@@ -1,0 +1,214 @@
+//
+//  PINCaching.h
+//  PINCache
+//
+//  Created by Michael Schneider on 1/31/17.
+//  Copyright © 2017 Pinterest. All rights reserved.
+//
+
+#pragma once
+#import <Foundation/Foundation.h>
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol PINCaching;
+
+/**
+ A callback block which provides only the cache as an argument
+ */
+typedef void (^PINCacheBlock)(id<PINCaching> cache);
+
+/**
+ A callback block which provides the cache, key and object as arguments
+ */
+typedef void (^PINCacheObjectBlock)(id<PINCaching> cache, NSString *key, id __nullable object);
+
+/**
+ A callback block which provides a BOOL value as argument
+ */
+typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
+
+@protocol PINCaching <NSObject>
+
+#pragma mark - Core
+
+/**
+ The name of this cache, used to create a directory under Library/Caches and also appearing in stack traces.
+ */
+@property (readonly) NSString *name;
+
+#pragma mark - Asynchronous Methods
+
+/// @name Asynchronous Methods
+
+/**
+ This method determines whether an object is present for the given key in the cache. This method returns immediately
+ and executes the passed block after the object is available, potentially in parallel with other blocks on the
+ <concurrentQueue>.
+ 
+ @see containsObjectForKey:
+ @param key The key associated with the object.
+ @param block A block to be executed concurrently after the containment check happened
+ */
+- (void)containsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block;
+
+/**
+ Retrieves the object for the specified key. This method returns immediately and executes the passed
+ block after the object is available, potentially in parallel with other blocks on the <concurrentQueue>.
+ 
+ @param key The key associated with the requested object.
+ @param block A block to be executed concurrently when the object is available.
+ */
+- (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block;
+
+/**
+ Stores an object in the cache for the specified key. This method returns immediately and executes the
+ passed block after the object has been stored, potentially in parallel with other blocks on the <concurrentQueue>.
+ 
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param block A block to be executed concurrently after the object has been stored, or nil.
+ */
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
+
+/**
+ Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
+ to go over the <memoryCache.costLimit> the cache is trimmed (oldest objects first). This method returns immediately
+ and executes the passed block after the object has been stored, potentially in parallel with other blocks
+ on the <concurrentQueue>.
+ 
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param cost An amount to add to the <memoryCache.totalCost>.
+ @param block A block to be executed concurrently after the object has been stored, or nil.
+ */
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
+
+/**
+ Removes the object for the specified key. This method returns immediately and executes the passed
+ block after the object has been removed, potentially in parallel with other blocks on the <concurrentQueue>.
+ 
+ @param key The key associated with the object to be removed.
+ @param block A block to be executed concurrently after the object has been removed, or nil.
+ */
+- (void)removeObjectForKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
+
+/**
+ Removes all objects from the cache that have not been used since the specified date. This method returns immediately and
+ executes the passed block after the cache has been trimmed, potentially in parallel with other blocks on the <concurrentQueue>.
+ 
+ @param date Objects that haven't been accessed since this date are removed from the cache.
+ @param block A block to be executed concurrently after the cache has been trimmed, or nil.
+ */
+- (void)trimToDate:(NSDate *)date block:(nullable PINCacheBlock)block;
+
+/**
+ Removes all objects from the cache.This method returns immediately and executes the passed block after the
+ cache has been cleared, potentially in parallel with other blocks on the <concurrentQueue>.
+ 
+ @param block A block to be executed concurrently after the cache has been cleared, or nil.
+ */
+- (void)removeAllObjects:(nullable PINCacheBlock)block;
+
+/**
+ Loops through all objects in the cache (reads and writes are suspended during the enumeration). Data is not actually
+ read from disk, the `object` parameter of the block will be `nil` but the `fileURL` will be available.
+ This method returns immediately.
+
+ @param block A block to be executed for every object in the cache.
+ @param completionBlock An optional block to be executed after the enumeration is complete.
+ 
+ @warning The PINDiskCache lock is held while block is executed. Any synchronous calls to the diskcache
+ or a cache which owns the instance of the disk cache are likely to cause a deadlock. This is why the block is
+ *not* passed the instance of the disk cache. You should also avoid doing extensive work while this
+ lock is held.
+ 
+ */
+//- (void)enumerateObjectsWithBlock:(PINCacheObjectBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
+
+
+#pragma mark - Synchronous Methods
+/// @name Synchronous Methods
+
+/**
+ This method determines whether an object is present for the given key in the cache.
+ 
+ @see containsObjectForKey:block:
+ @param key The key associated with the object.
+ @result YES if an object is present for the given key in the cache, otherwise NO.
+ */
+- (BOOL)containsObjectForKey:(NSString *)key;
+
+/**
+ Retrieves the object for the specified key. This method blocks the calling thread until the object is available.
+ Uses a lock to achieve synchronicity on the disk cache.
+ 
+ @see objectForKey:block:
+ @param key The key associated with the object.
+ @result The object for the specified key.
+ */
+- (nullable id)objectForKey:(NSString *)key;
+
+/**
+ Stores an object in the cache for the specified key. This method blocks the calling thread until the object has been set.
+ Uses a lock to achieve synchronicity on the disk cache.
+ 
+ @see setObject:forKey:block:
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ */
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
+
+/**
+ Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
+ to go over the <memoryCache.costLimit> the cache is trimmed (oldest objects first). This method blocks the calling thread
+ until the object has been stored.
+ 
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param cost An amount to add to the <memoryCache.totalCost>.
+ */
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost;
+
+/**
+ Removes the object for the specified key. This method blocks the calling thread until the object
+ has been removed.
+ Uses a lock to achieve synchronicity on the disk cache.
+ 
+ @param key The key associated with the object to be removed.
+ */
+- (void)removeObjectForKey:(NSString *)key;
+
+/**
+ Removes all objects from the cache that have not been used since the specified date.
+ This method blocks the calling thread until the cache has been trimmed.
+ Uses a lock to achieve synchronicity on the disk cache.
+ 
+ @param date Objects that haven't been accessed since this date are removed from the cache.
+ */
+- (void)trimToDate:(NSDate *)date;
+
+/**
+ Removes all objects from the cache. This method blocks the calling thread until the cache has been cleared.
+ Uses a lock to achieve synchronicity on the disk cache.
+ */
+- (void)removeAllObjects;
+
+/**
+ Loops through all objects in the cache within a memory lock (reads and writes are suspended during the enumeration).
+ This method blocks the calling thread until all objects have been enumerated.
+ Calling synchronous methods on the cache within this callback will likely cause a deadlock.
+ 
+ @param block A block to be executed for every object in the cache.
+ 
+ @warning Do not call this method within the event blocks (<didReceiveMemoryWarningBlock>, etc.)
+ Instead use the asynchronous version, <enumerateObjectsWithBlock:completionBlock:>.
+ 
+ */
+//- (void)enumerateObjectsWithBlock:(nullable PINCacheBlock)block;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/Source/PINCaching.h
+++ b/Source/PINCaching.h
@@ -51,7 +51,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key The key associated with the object.
  @param block A block to be executed concurrently after the containment check happened
  */
-- (void)containsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block;
+- (void)asyncContainsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block;
 
 /**
  Retrieves the object for the specified key. This method returns immediately and executes the passed
@@ -60,7 +60,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key The key associated with the requested object.
  @param block A block to be executed concurrently when the object is available.
  */
-- (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block;
+- (void)asyncObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
@@ -70,7 +70,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key A key to associate with the object. This string will be copied.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
+- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
@@ -83,7 +83,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param cost An amount to add to the <memoryCache.totalCost>.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
+- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed
@@ -92,7 +92,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key The key associated with the object to be removed.
  @param block A block to be executed concurrently after the object has been removed, or nil.
  */
-- (void)removeObjectForKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
+- (void)asyncRemoveObjectForKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes all objects from the cache that have not been used since the specified date. This method returns immediately and
@@ -101,7 +101,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param date Objects that haven't been accessed since this date are removed from the cache.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)trimToDate:(NSDate *)date block:(nullable PINCacheBlock)block;
+- (void)asyncTrimToDate:(NSDate *)date block:(nullable PINCacheBlock)block;
 
 /**
  Removes all objects from the cache.This method returns immediately and executes the passed block after the
@@ -109,23 +109,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  
  @param block A block to be executed concurrently after the cache has been cleared, or nil.
  */
-- (void)removeAllObjects:(nullable PINCacheBlock)block;
-
-/**
- Loops through all objects in the cache (reads and writes are suspended during the enumeration). Data is not actually
- read from disk, the `object` parameter of the block will be `nil` but the `fileURL` will be available.
- This method returns immediately.
-
- @param block A block to be executed for every object in the cache.
- @param completionBlock An optional block to be executed after the enumeration is complete.
- 
- @warning The PINDiskCache lock is held while block is executed. Any synchronous calls to the diskcache
- or a cache which owns the instance of the disk cache are likely to cause a deadlock. This is why the block is
- *not* passed the instance of the disk cache. You should also avoid doing extensive work while this
- lock is held.
- 
- */
-//- (void)enumerateObjectsWithBlock:(PINCacheObjectBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
+- (void)asyncRemoveAllObjects:(nullable PINCacheBlock)block;
 
 
 #pragma mark - Synchronous Methods
@@ -194,19 +178,6 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  Uses a lock to achieve synchronicity on the disk cache.
  */
 - (void)removeAllObjects;
-
-/**
- Loops through all objects in the cache within a memory lock (reads and writes are suspended during the enumeration).
- This method blocks the calling thread until all objects have been enumerated.
- Calling synchronous methods on the cache within this callback will likely cause a deadlock.
- 
- @param block A block to be executed for every object in the cache.
- 
- @warning Do not call this method within the event blocks (<didReceiveMemoryWarningBlock>, etc.)
- Instead use the asynchronous version, <enumerateObjectsWithBlock:completionBlock:>.
- 
- */
-//- (void)enumerateObjectsWithBlock:(nullable PINCacheBlock)block;
 
 @end
 

--- a/Source/PINCaching.h
+++ b/Source/PINCaching.h
@@ -51,7 +51,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key The key associated with the object.
  @param block A block to be executed concurrently after the containment check happened
  */
-- (void)containsObjectForKeyAsync:(NSString *)key block:(PINCacheObjectContainmentBlock)block;
+- (void)containsObjectForKeyAsync:(NSString *)key completion:(PINCacheObjectContainmentBlock)block;
 
 /**
  Retrieves the object for the specified key. This method returns immediately and executes the passed
@@ -60,7 +60,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key The key associated with the requested object.
  @param block A block to be executed concurrently when the object is available.
  */
-- (void)objectForKeyAsync:(NSString *)key block:(PINCacheObjectBlock)block;
+- (void)objectForKeyAsync:(NSString *)key completion:(PINCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
@@ -70,7 +70,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key A key to associate with the object. This string will be copied.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)setObjectAsync:(id)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
+- (void)setObjectAsync:(id)object forKey:(NSString *)key completion:(nullable PINCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
@@ -83,7 +83,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param cost An amount to add to the <memoryCache.totalCost>.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)setObjectAsync:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
+- (void)setObjectAsync:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost completion:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed
@@ -92,7 +92,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key The key associated with the object to be removed.
  @param block A block to be executed concurrently after the object has been removed, or nil.
  */
-- (void)removeObjectForKeyAsync:(NSString *)key block:(nullable PINCacheObjectBlock)block;
+- (void)removeObjectForKeyAsync:(NSString *)key completion:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes all objects from the cache that have not been used since the specified date. This method returns immediately and
@@ -101,7 +101,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param date Objects that haven't been accessed since this date are removed from the cache.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)trimToDateAsync:(NSDate *)date block:(nullable PINCacheBlock)block;
+- (void)trimToDateAsync:(NSDate *)date completion:(nullable PINCacheBlock)block;
 
 /**
  Removes all objects from the cache.This method returns immediately and executes the passed block after the

--- a/Source/PINCaching.h
+++ b/Source/PINCaching.h
@@ -51,7 +51,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key The key associated with the object.
  @param block A block to be executed concurrently after the containment check happened
  */
-- (void)asyncContainsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block;
+- (void)containsObjectForKeyAsync:(NSString *)key block:(PINCacheObjectContainmentBlock)block;
 
 /**
  Retrieves the object for the specified key. This method returns immediately and executes the passed
@@ -60,7 +60,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key The key associated with the requested object.
  @param block A block to be executed concurrently when the object is available.
  */
-- (void)asyncObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block;
+- (void)objectForKeyAsync:(NSString *)key block:(PINCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
@@ -70,7 +70,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key A key to associate with the object. This string will be copied.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)asyncSetObject:(id)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
+- (void)setObjectAsync:(id)object forKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
@@ -83,7 +83,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param cost An amount to add to the <memoryCache.totalCost>.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)asyncSetObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
+- (void)setObjectAsync:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed
@@ -92,7 +92,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param key The key associated with the object to be removed.
  @param block A block to be executed concurrently after the object has been removed, or nil.
  */
-- (void)asyncRemoveObjectForKey:(NSString *)key block:(nullable PINCacheObjectBlock)block;
+- (void)removeObjectForKeyAsync:(NSString *)key block:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes all objects from the cache that have not been used since the specified date. This method returns immediately and
@@ -101,7 +101,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  @param date Objects that haven't been accessed since this date are removed from the cache.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)asyncTrimToDate:(NSDate *)date block:(nullable PINCacheBlock)block;
+- (void)trimToDateAsync:(NSDate *)date block:(nullable PINCacheBlock)block;
 
 /**
  Removes all objects from the cache.This method returns immediately and executes the passed block after the
@@ -109,7 +109,7 @@ typedef void (^PINCacheObjectContainmentBlock)(BOOL containsObject);
  
  @param block A block to be executed concurrently after the cache has been cleared, or nil.
  */
-- (void)asyncRemoveAllObjects:(nullable PINCacheBlock)block;
+- (void)removeAllObjectsAsync:(nullable PINCacheBlock)block;
 
 
 #pragma mark - Synchronous Methods

--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -406,19 +406,10 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
 - (void)synchronouslyLockFileAccessWhileExecutingBlock:(nullable PINCacheBlock)block;
 
 /**
- This method determines whether an object is present for the given key in the cache.
- 
- @see containsObjectForKey:block:
- @param key The key associated with the object.
- @result YES if an object is present for the given key in the cache, otherwise NO.
- */
-//- (BOOL)containsObjectForKey:(NSString *)key;
-
-/**
  Retrieves the object for the specified key. This method blocks the calling thread until the
  object is available.
  
- @see objectForKey:block:
+ @see objectForKeyAsync:completion:
  @param key The key associated with the object.
  @result The object for the specified key.
  */
@@ -429,7 +420,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  url is available. Do not use this URL anywhere except with <lockFileAccessWhileExecutingBlock:>. This method probably
  shouldn't even exist, just use the asynchronous one.
  
- @see fileURLForKey:block:
+ @see fileURLForKeyAsync:completion:
  @param key The key associated with the object.
  @result The file URL for the specified key.
  */
@@ -439,7 +430,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  Stores an object in the cache for the specified key. This method blocks the calling thread until
  the object has been stored.
  
- @see setObject:forKey:block:
+ @see setObjectAsync:forKey:completion:
  @param object An object to store in the cache.
  @param key A key to associate with the object. This string will be copied.
  */
@@ -449,6 +440,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  Removes objects from the cache, largest first, until the cache is equal to or smaller than the
  specified byteCount. This method blocks the calling thread until the cache has been trimmed.
  
+ @see trimToSizeAsync:
  @param byteCount The cache will be trimmed equal to or smaller than this size.
  */
 - (void)trimToSize:(NSUInteger)byteCount;
@@ -456,6 +448,8 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
 /**
  Removes objects from the cache, ordered by date (least recently used first), until the cache is equal to or
  smaller than the specified byteCount. This method blocks the calling thread until the cache has been trimmed.
+ 
+ @see trimToSizeByDateAsync:
  @param byteCount The cache will be trimmed equal to or smaller than this size.
  */
 - (void)trimToSizeByDate:(NSUInteger)byteCount;
@@ -464,6 +458,8 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  Loops through all objects in the cache (reads and writes are suspended during the enumeration). Data is not actually
  read from disk, the `object` parameter of the block will be `nil` but the `fileURL` will be available.
  This method blocks the calling thread until all objects have been enumerated.
+ 
+ @see enumerateObjectsWithBlockAsync:completionBlock
  @param block A block to be executed for every object in the cache.
  
  @warning Do not call this method within the event blocks (<didRemoveObjectBlock>, etc.)

--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -306,7 +306,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  @param key The key associated with the requested object.
  @param block A block to be executed serially when the object is available.
  */
-- (void)objectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+- (void)asyncObjectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Retrieves the fileURL for the specified key without actually reading the data from disk. This method
@@ -323,7 +323,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  @param key The key associated with the requested object.
  @param block A block to be executed serially when the file URL is available.
  */
-- (void)fileURLForKey:(NSString *)key block:(nullable PINDiskCacheFileURLBlock)block;
+- (void)asyncFileURLForKey:(NSString *)key block:(nullable PINDiskCacheFileURLBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
@@ -333,7 +333,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  @param key A key to associate with the object. This string will be copied.
  @param block A block to be executed serially after the object has been stored, or nil.
  */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed block
@@ -342,7 +342,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  @param key The key associated with the object to be removed.
  @param block A block to be executed serially after the object has been removed, or nil.
  */
-- (void)removeObjectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+- (void)asyncRemoveObjectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Removes objects from the cache, largest first, until the cache is equal to or smaller than the specified byteCount.
@@ -351,7 +351,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  @param byteCount The cache will be trimmed equal to or smaller than this size.
  @param block A block to be executed serially after the cache has been trimmed, or nil.
  */
-- (void)trimToSize:(NSUInteger)byteCount block:(nullable PINCacheBlock)block;
+- (void)asyncTrimToSize:(NSUInteger)byteCount block:(nullable PINCacheBlock)block;
 
 /**
  Removes objects from the cache, ordered by date (least recently used first), until the cache is equal to or smaller
@@ -361,7 +361,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  @param byteCount The cache will be trimmed equal to or smaller than this size.
  @param block A block to be executed serially after the cache has been trimmed, or nil.
  */
-- (void)trimToSizeByDate:(NSUInteger)byteCount block:(nullable PINCacheBlock)block;
+- (void)asyncTrimToSizeByDate:(NSUInteger)byteCount block:(nullable PINCacheBlock)block;
 
 /**
  Loops through all objects in the cache (reads and writes are suspended during the enumeration). Data is not actually
@@ -377,7 +377,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  lock is held.
  
  */
-- (void)enumerateObjectsWithBlock:(PINDiskCacheFileURLBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
+- (void)asyncEnumerateObjectsWithBlock:(PINDiskCacheFileURLBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
 
 #pragma mark - Synchronous Methods
 /// @name Synchronous Methods

--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -297,7 +297,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  
  @param block A block to be executed when a lock is available.
  */
-- (void)lockFileAccessWhileExecutingBlock:(nullable PINCacheBlock)block;
+- (void)asyncLockFileAccessWhileExecutingBlock:(nullable PINCacheBlock)block;
 
 /**
  Retrieves the object for the specified key. This method returns immediately and executes the passed
@@ -464,6 +464,33 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  */
 - (void)enumerateObjectsWithBlock:(nullable PINDiskCacheFileURLBlock)block;
 
+@end
+
+
+#pragma mark - Deprecated
+
+/**
+ A callback block which provides only the cache as an argument
+ */
+typedef void (^PINDiskCacheBlock)(PINDiskCache *cache);
+
+/**
+ A callback block which provides the cache, key and object as arguments
+ */
+typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding>  __nullable object);
+
+@interface PINDiskCache (Deprecated)
+- (void)lockFileAccessWhileExecutingBlock:(nullable PINCacheBlock)block __attribute__((deprecated));
+- (void)containsObjectForKey:(NSString *)key block:(PINDiskCacheContainsBlock)block __attribute__((deprecated));
+- (void)objectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block __attribute__((deprecated));
+- (void)fileURLForKey:(NSString *)key block:(nullable PINDiskCacheFileURLBlock)block __attribute__((deprecated));
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block __attribute__((deprecated));
+- (void)removeObjectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block __attribute__((deprecated));
+- (void)trimToDate:(NSDate *)date block:(nullable PINDiskCacheBlock)block __attribute__((deprecated));
+- (void)trimToSize:(NSUInteger)byteCount block:(nullable PINDiskCacheBlock)block __attribute__((deprecated));
+- (void)trimToSizeByDate:(NSUInteger)byteCount block:(nullable PINDiskCacheBlock)block __attribute__((deprecated));
+- (void)removeAllObjects:(nullable PINDiskCacheBlock)block __attribute__((deprecated));
+- (void)enumerateObjectsWithBlock:(PINDiskCacheFileURLBlock)block completionBlock:(nullable PINDiskCacheBlock)completionBlock __attribute__((deprecated));
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -297,7 +297,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  
  @param block A block to be executed when a lock is available.
  */
-- (void)asyncLockFileAccessWhileExecutingBlock:(nullable PINCacheBlock)block;
+- (void)lockFileAccessWhileExecutingBlockAsync:(nullable PINCacheBlock)block;
 
 /**
  Retrieves the object for the specified key. This method returns immediately and executes the passed
@@ -306,7 +306,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param key The key associated with the requested object.
  @param block A block to be executed serially when the object is available.
  */
-- (void)asyncObjectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+- (void)objectForKeyAsync:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Retrieves the fileURL for the specified key without actually reading the data from disk. This method
@@ -323,7 +323,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param key The key associated with the requested object.
  @param block A block to be executed serially when the file URL is available.
  */
-- (void)asyncFileURLForKey:(NSString *)key block:(nullable PINDiskCacheFileURLBlock)block;
+- (void)fileURLForKeyAsync:(NSString *)key block:(nullable PINDiskCacheFileURLBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
@@ -333,7 +333,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param key A key to associate with the object. This string will be copied.
  @param block A block to be executed serially after the object has been stored, or nil.
  */
-- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
@@ -346,7 +346,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param cost An amount to add to the <memoryCache.totalCost>.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
+- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed block
@@ -355,7 +355,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param key The key associated with the object to be removed.
  @param block A block to be executed serially after the object has been removed, or nil.
  */
-- (void)asyncRemoveObjectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+- (void)removeObjectForKeyAsync:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Removes objects from the cache, largest first, until the cache is equal to or smaller than the specified byteCount.
@@ -364,7 +364,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param byteCount The cache will be trimmed equal to or smaller than this size.
  @param block A block to be executed serially after the cache has been trimmed, or nil.
  */
-- (void)asyncTrimToSize:(NSUInteger)byteCount block:(nullable PINCacheBlock)block;
+- (void)trimToSizeAsync:(NSUInteger)byteCount block:(nullable PINCacheBlock)block;
 
 /**
  Removes objects from the cache, ordered by date (least recently used first), until the cache is equal to or smaller
@@ -374,7 +374,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param byteCount The cache will be trimmed equal to or smaller than this size.
  @param block A block to be executed serially after the cache has been trimmed, or nil.
  */
-- (void)asyncTrimToSizeByDate:(NSUInteger)byteCount block:(nullable PINCacheBlock)block;
+- (void)trimToSizeByDateAsync:(NSUInteger)byteCount block:(nullable PINCacheBlock)block;
 
 /**
  Loops through all objects in the cache (reads and writes are suspended during the enumeration). Data is not actually
@@ -390,7 +390,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  lock is held.
  
  */
-- (void)asyncEnumerateObjectsWithBlock:(PINDiskCacheFileURLBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
+- (void)enumerateObjectsWithBlockAsync:(PINDiskCacheFileURLBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
 
 #pragma mark - Synchronous Methods
 /// @name Synchronous Methods

--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -4,8 +4,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "PINCaching.h"
-#import "PINCacheObjectSubscripting.h"
+#import <PINCache/PINCaching.h>
+#import <PINCache/PINCacheObjectSubscripting.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,12 +17,12 @@ extern NSString * const PINDiskCachePrefix;
 /**
  A callback block which provides the cache, key and object as arguments
  */
-typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding>  __nullable object);
+typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding>  _Nullable object);
 
 /**
  A callback block which provides the key and fileURL of the object
  */
-typedef void (^PINDiskCacheFileURLBlock)(NSString *key, NSURL * __nullable fileURL);
+typedef void (^PINDiskCacheFileURLBlock)(NSString *key, NSURL * _Nullable fileURL);
 
 /**
  A callback block which provides a BOOL value as argument
@@ -37,7 +37,7 @@ typedef void (^PINDiskCacheContainsBlock)(BOOL containsObject);
  *
  *  @return Serialized object representation
  */
-typedef NSData* __nonnull(^PINDiskCacheSerializerBlock)(id<NSCoding> object, NSString *key);
+typedef NSData* _Nonnull(^PINDiskCacheSerializerBlock)(id<NSCoding> object, NSString *key);
 
 /**
  *  A block used to deserialize objects
@@ -47,7 +47,7 @@ typedef NSData* __nonnull(^PINDiskCacheSerializerBlock)(id<NSCoding> object, NSS
  *
  *  @return Deserialized object
  */
-typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSString *key);
+typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSString *key);
 
 
 /**
@@ -137,7 +137,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
 /**
  Extension for all cache files on disk. Defaults to no extension. 
  */
-@property (readonly) NSString * __nullable fileExtension;
+@property (nullable, readonly) NSString * fileExtension;
 
 /**
  The writing protection option used when writing a file on disk. This value is used every time an object is set.
@@ -169,34 +169,34 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
 /**
  A block to be executed just before an object is added to the cache. The queue waits during execution.
  */
-@property (copy) PINDiskCacheObjectBlock __nullable willAddObjectBlock;
+@property (nullable, copy) PINDiskCacheObjectBlock willAddObjectBlock;
 
 /**
  A block to be executed just before an object is removed from the cache. The queue waits during execution.
  */
-@property (copy) PINDiskCacheObjectBlock __nullable willRemoveObjectBlock;
+@property (nullable, copy) PINDiskCacheObjectBlock willRemoveObjectBlock;
 
 /**
  A block to be executed just before all objects are removed from the cache as a result of <removeAllObjects:>.
  The queue waits during execution.
  */
-@property (copy) PINCacheBlock __nullable willRemoveAllObjectsBlock;
+@property (nullable, copy) PINCacheBlock willRemoveAllObjectsBlock;
 
 /**
  A block to be executed just after an object is added to the cache. The queue waits during execution.
  */
-@property (copy) PINDiskCacheObjectBlock __nullable didAddObjectBlock;
+@property (nullable, copy) PINDiskCacheObjectBlock didAddObjectBlock;
 
 /**
  A block to be executed just after an object is removed from the cache. The queue waits during execution.
  */
-@property (copy) PINDiskCacheObjectBlock __nullable didRemoveObjectBlock;
+@property (nullable, copy) PINDiskCacheObjectBlock didRemoveObjectBlock;
 
 /**
  A block to be executed just after all objects are removed from the cache as a result of <removeAllObjects:>.
  The queue waits during execution.
  */
-@property (copy) PINCacheBlock __nullable didRemoveAllObjectsBlock;
+@property (nullable, copy) PINCacheBlock didRemoveAllObjectsBlock;
 
 #pragma mark - Lifecycle
 /// @name Initialization
@@ -336,6 +336,19 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
 - (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
 
 /**
+ Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
+ to go over the <memoryCache.costLimit> the cache is trimmed (oldest objects first). This method returns immediately
+ and executes the passed block after the object has been stored, potentially in parallel with other blocks
+ on the <concurrentQueue>.
+ 
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param cost An amount to add to the <memoryCache.totalCost>.
+ @param block A block to be executed concurrently after the object has been stored, or nil.
+ */
+- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
+
+/**
  Removes the object for the specified key. This method returns immediately and executes the passed block
  as soon as the object has been removed.
  
@@ -409,7 +422,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  @param key The key associated with the object.
  @result The object for the specified key.
  */
-- (__nullable id <NSCoding>)objectForKey:(NSString *)key;
+- (nullable id <NSCoding>)objectForKey:(NSString *)key;
 
 /**
  Retrieves the file URL for the specified key. This method blocks the calling thread until the
@@ -430,7 +443,7 @@ typedef id<NSCoding> __nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSS
  @param object An object to store in the cache.
  @param key A key to associate with the object. This string will be copied.
  */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
+- (void)setObject:(nullable id <NSCoding>)object forKey:(NSString *)key;
 
 /**
  Removes objects from the cache, largest first, until the cache is equal to or smaller than the

--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -306,7 +306,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param key The key associated with the requested object.
  @param block A block to be executed serially when the object is available.
  */
-- (void)objectForKeyAsync:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+- (void)objectForKeyAsync:(NSString *)key completion:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Retrieves the fileURL for the specified key without actually reading the data from disk. This method
@@ -323,7 +323,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param key The key associated with the requested object.
  @param block A block to be executed serially when the file URL is available.
  */
-- (void)fileURLForKeyAsync:(NSString *)key block:(nullable PINDiskCacheFileURLBlock)block;
+- (void)fileURLForKeyAsync:(NSString *)key completion:(nullable PINDiskCacheFileURLBlock)block;
 
 /**
  Stores an object in the cache for the specified key. This method returns immediately and executes the
@@ -333,7 +333,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param key A key to associate with the object. This string will be copied.
  @param block A block to be executed serially after the object has been stored, or nil.
  */
-- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key completion:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Stores an object in the cache for the specified key and the specified memory cost. If the cost causes the total
@@ -346,7 +346,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param cost An amount to add to the <memoryCache.totalCost>.
  @param block A block to be executed concurrently after the object has been stored, or nil.
  */
-- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block;
+- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost completion:(nullable PINCacheObjectBlock)block;
 
 /**
  Removes the object for the specified key. This method returns immediately and executes the passed block
@@ -355,7 +355,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param key The key associated with the object to be removed.
  @param block A block to be executed serially after the object has been removed, or nil.
  */
-- (void)removeObjectForKeyAsync:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block;
+- (void)removeObjectForKeyAsync:(NSString *)key completion:(nullable PINDiskCacheObjectBlock)block;
 
 /**
  Removes objects from the cache, largest first, until the cache is equal to or smaller than the specified byteCount.
@@ -364,7 +364,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param byteCount The cache will be trimmed equal to or smaller than this size.
  @param block A block to be executed serially after the cache has been trimmed, or nil.
  */
-- (void)trimToSizeAsync:(NSUInteger)byteCount block:(nullable PINCacheBlock)block;
+- (void)trimToSizeAsync:(NSUInteger)byteCount completion:(nullable PINCacheBlock)block;
 
 /**
  Removes objects from the cache, ordered by date (least recently used first), until the cache is equal to or smaller
@@ -374,7 +374,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
  @param byteCount The cache will be trimmed equal to or smaller than this size.
  @param block A block to be executed serially after the cache has been trimmed, or nil.
  */
-- (void)trimToSizeByDateAsync:(NSUInteger)byteCount block:(nullable PINCacheBlock)block;
+- (void)trimToSizeByDateAsync:(NSUInteger)byteCount completion:(nullable PINCacheBlock)block;
 
 /**
  Loops through all objects in the cache (reads and writes are suspended during the enumeration). Data is not actually

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -599,7 +599,7 @@ static NSURL *_sharedTrashURL;
 
 #pragma mark - Public Asynchronous Methods -
 
-- (void)lockFileAccessWhileExecutingBlock:(PINCacheBlock)block
+- (void)asyncLockFileAccessWhileExecutingBlock:(PINCacheBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -1340,6 +1340,65 @@ static NSURL *_sharedTrashURL;
 - (void)unlock
 {
     [_instanceLock unlockWithCondition:PINDiskCacheConditionReady];
+}
+
+@end
+
+@implementation PINDiskCache (Deprecated)
+
+- (void)lockFileAccessWhileExecutingBlock:(nullable PINCacheBlock)block
+{
+    [self asyncLockFileAccessWhileExecutingBlock:block];
+}
+
+- (void)containsObjectForKey:(NSString *)key block:(PINDiskCacheContainsBlock)block
+{
+    [self asyncContainsObjectForKey:key block:block];
+}
+
+- (void)objectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block
+{
+    [self asyncObjectForKey:key block:block];
+}
+
+- (void)fileURLForKey:(NSString *)key block:(nullable PINDiskCacheFileURLBlock)block
+{
+    [self asyncFileURLForKey:key block:block];
+}
+
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block
+{
+    [self asyncSetObject:object forKey:key block:block];
+}
+
+- (void)removeObjectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block
+{
+    [self asyncRemoveObjectForKey:key block:block];
+}
+
+- (void)trimToDate:(NSDate *)date block:(nullable PINDiskCacheBlock)block
+{
+    [self asyncTrimToDate:date block:block];
+}
+
+- (void)trimToSize:(NSUInteger)byteCount block:(nullable PINDiskCacheBlock)block
+{
+    [self asyncTrimToSize:byteCount block:block];
+}
+
+- (void)trimToSizeByDate:(NSUInteger)byteCount block:(nullable PINDiskCacheBlock)block
+{
+    [self asyncTrimToSize:byteCount block:block];
+}
+
+- (void)removeAllObjects:(nullable PINDiskCacheBlock)block
+{
+    [self asyncRemoveAllObjects:block];
+}
+
+- (void)enumerateObjectsWithBlock:(PINDiskCacheFileURLBlock)block completionBlock:(nullable PINDiskCacheBlock)completionBlock
+{
+    [self asyncEnumerateObjectsWithBlock:block completionBlock:completionBlock];
 }
 
 @end

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -613,7 +613,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)containsObjectForKeyAsync:(NSString *)key block:(PINDiskCacheContainsBlock)block
+- (void)containsObjectForKeyAsync:(NSString *)key completion:(PINDiskCacheContainsBlock)block
 {
     if (!key || !block)
         return;
@@ -626,7 +626,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)objectForKeyAsync:(NSString *)key block:(PINDiskCacheObjectBlock)block
+- (void)objectForKeyAsync:(NSString *)key completion:(PINDiskCacheObjectBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -639,7 +639,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)fileURLForKeyAsync:(NSString *)key block:(PINDiskCacheFileURLBlock)block
+- (void)fileURLForKeyAsync:(NSString *)key completion:(PINDiskCacheFileURLBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -655,7 +655,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key block:(PINDiskCacheObjectBlock)block
+- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key completion:(PINDiskCacheObjectBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -670,12 +670,12 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block
+- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost completion:(nullable PINCacheObjectBlock)block
 {
-    [self setObjectAsync:object forKey:key block:(PINDiskCacheObjectBlock)block];
+    [self setObjectAsync:object forKey:key completion:(PINDiskCacheObjectBlock)block];
 }
 
-- (void)removeObjectForKeyAsync:(NSString *)key block:(PINDiskCacheObjectBlock)block
+- (void)removeObjectForKeyAsync:(NSString *)key completion:(PINDiskCacheObjectBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -690,7 +690,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)trimToSizeAsync:(NSUInteger)trimByteCount block:(PINCacheBlock)block
+- (void)trimToSizeAsync:(NSUInteger)trimByteCount completion:(PINCacheBlock)block
 {
     PINOperationBlock operation = ^(id data) {
         [self trimToSize:((NSNumber *)data).unsignedIntegerValue];
@@ -711,7 +711,7 @@ static NSURL *_sharedTrashURL;
                            completion:completion];
 }
 
-- (void)trimToDateAsync:(NSDate *)trimDate block:(PINCacheBlock)block
+- (void)trimToDateAsync:(NSDate *)trimDate completion:(PINCacheBlock)block
 {
     PINOperationBlock operation = ^(id data){
         [self trimToDate:(NSDate *)data];
@@ -732,7 +732,7 @@ static NSURL *_sharedTrashURL;
                            completion:completion];
 }
 
-- (void)trimToSizeByDateAsync:(NSUInteger)trimByteCount block:(PINCacheBlock)block
+- (void)trimToSizeByDateAsync:(NSUInteger)trimByteCount completion:(PINCacheBlock)block
 {
     PINOperationBlock operation = ^(id data){
         [self trimToSizeByDate:((NSNumber *)data).unsignedIntegerValue];
@@ -948,7 +948,7 @@ static NSURL *_sharedTrashURL;
             }
             
             if (self->_byteLimit > 0 && self->_byteCount > self->_byteLimit)
-                [self trimToSizeByDateAsync:self->_byteLimit block:nil];
+                [self trimToSizeByDateAsync:self->_byteLimit completion:nil];
         } else {
             fileURL = nil;
         }
@@ -1355,42 +1355,42 @@ static NSURL *_sharedTrashURL;
 
 - (void)containsObjectForKey:(NSString *)key block:(PINDiskCacheContainsBlock)block
 {
-    [self containsObjectForKeyAsync:key block:block];
+    [self containsObjectForKeyAsync:key completion:block];
 }
 
 - (void)objectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block
 {
-    [self objectForKeyAsync:key block:block];
+    [self objectForKeyAsync:key completion:block];
 }
 
 - (void)fileURLForKey:(NSString *)key block:(nullable PINDiskCacheFileURLBlock)block
 {
-    [self fileURLForKeyAsync:key block:block];
+    [self fileURLForKeyAsync:key completion:block];
 }
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block
 {
-    [self setObjectAsync:object forKey:key block:block];
+    [self setObjectAsync:object forKey:key completion:block];
 }
 
 - (void)removeObjectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block
 {
-    [self removeObjectForKeyAsync:key block:block];
+    [self removeObjectForKeyAsync:key completion:block];
 }
 
 - (void)trimToDate:(NSDate *)date block:(nullable PINDiskCacheBlock)block
 {
-    [self trimToDateAsync:date block:block];
+    [self trimToDateAsync:date completion:block];
 }
 
 - (void)trimToSize:(NSUInteger)byteCount block:(nullable PINDiskCacheBlock)block
 {
-    [self trimToSizeAsync:byteCount block:block];
+    [self trimToSizeAsync:byteCount completion:block];
 }
 
 - (void)trimToSizeByDate:(NSUInteger)byteCount block:(nullable PINDiskCacheBlock)block
 {
-    [self trimToSizeAsync:byteCount block:block];
+    [self trimToSizeAsync:byteCount completion:block];
 }
 
 - (void)removeAllObjects:(nullable PINDiskCacheBlock)block

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -635,9 +635,7 @@ static NSURL *_sharedTrashURL;
         NSURL *fileURL = nil;
         id <NSCoding> object = [strongSelf objectForKey:key fileURL:&fileURL];
         
-        if (block) {
-            block(strongSelf, key, object);
-        }
+        block(strongSelf, key, object);
     } withPriority:PINOperationQueuePriorityLow];
 }
 
@@ -809,7 +807,7 @@ static NSURL *_sharedTrashURL;
     return [self objectForKey:key];
 }
 
-- (__nullable id <NSCoding>)objectForKey:(NSString *)key fileURL:(NSURL **)outFileURL
+- (nullable id <NSCoding>)objectForKey:(NSString *)key fileURL:(NSURL **)outFileURL
 {
     NSDate *now = [[NSDate alloc] init];
     
@@ -892,7 +890,11 @@ static NSURL *_sharedTrashURL;
 
 - (void)setObject:(id)object forKeyedSubscript:(NSString *)key
 {
-    [self setObject:object forKey:key];
+    if (object == nil) {
+        [self removeObjectForKey:key];
+    } else {
+        [self setObject:object forKey:key];
+    }
 }
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key fileURL:(NSURL **)outFileURL

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -599,7 +599,7 @@ static NSURL *_sharedTrashURL;
 
 #pragma mark - Public Asynchronous Methods -
 
-- (void)asyncLockFileAccessWhileExecutingBlock:(PINCacheBlock)block
+- (void)lockFileAccessWhileExecutingBlockAsync:(PINCacheBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -613,7 +613,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)asyncContainsObjectForKey:(NSString *)key block:(PINDiskCacheContainsBlock)block
+- (void)containsObjectForKeyAsync:(NSString *)key block:(PINDiskCacheContainsBlock)block
 {
     if (!key || !block)
         return;
@@ -626,7 +626,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)asyncObjectForKey:(NSString *)key block:(PINDiskCacheObjectBlock)block
+- (void)objectForKeyAsync:(NSString *)key block:(PINDiskCacheObjectBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -639,7 +639,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)asyncFileURLForKey:(NSString *)key block:(PINDiskCacheFileURLBlock)block
+- (void)fileURLForKeyAsync:(NSString *)key block:(PINDiskCacheFileURLBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -655,7 +655,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key block:(PINDiskCacheObjectBlock)block
+- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key block:(PINDiskCacheObjectBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -670,12 +670,12 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block
+- (void)setObjectAsync:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block
 {
-    [self asyncSetObject:object forKey:key block:(PINDiskCacheObjectBlock)block];
+    [self setObjectAsync:object forKey:key block:(PINDiskCacheObjectBlock)block];
 }
 
-- (void)asyncRemoveObjectForKey:(NSString *)key block:(PINDiskCacheObjectBlock)block
+- (void)removeObjectForKeyAsync:(NSString *)key block:(PINDiskCacheObjectBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -690,7 +690,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)asyncTrimToSize:(NSUInteger)trimByteCount block:(PINCacheBlock)block
+- (void)trimToSizeAsync:(NSUInteger)trimByteCount block:(PINCacheBlock)block
 {
     PINOperationBlock operation = ^(id data) {
         [self trimToSize:((NSNumber *)data).unsignedIntegerValue];
@@ -711,7 +711,7 @@ static NSURL *_sharedTrashURL;
                            completion:completion];
 }
 
-- (void)asyncTrimToDate:(NSDate *)trimDate block:(PINCacheBlock)block
+- (void)trimToDateAsync:(NSDate *)trimDate block:(PINCacheBlock)block
 {
     PINOperationBlock operation = ^(id data){
         [self trimToDate:(NSDate *)data];
@@ -732,7 +732,7 @@ static NSURL *_sharedTrashURL;
                            completion:completion];
 }
 
-- (void)asyncTrimToSizeByDate:(NSUInteger)trimByteCount block:(PINCacheBlock)block
+- (void)trimToSizeByDateAsync:(NSUInteger)trimByteCount block:(PINCacheBlock)block
 {
     PINOperationBlock operation = ^(id data){
         [self trimToSizeByDate:((NSNumber *)data).unsignedIntegerValue];
@@ -753,7 +753,7 @@ static NSURL *_sharedTrashURL;
                            completion:completion];
 }
 
-- (void)asyncRemoveAllObjects:(PINCacheBlock)block
+- (void)removeAllObjectsAsync:(PINCacheBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -767,7 +767,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)asyncEnumerateObjectsWithBlock:(PINDiskCacheFileURLBlock)block completionBlock:(PINCacheBlock)completionBlock
+- (void)enumerateObjectsWithBlockAsync:(PINDiskCacheFileURLBlock)block completionBlock:(PINCacheBlock)completionBlock
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -948,7 +948,7 @@ static NSURL *_sharedTrashURL;
             }
             
             if (self->_byteLimit > 0 && self->_byteCount > self->_byteLimit)
-                [self asyncTrimToSizeByDate:self->_byteLimit block:nil];
+                [self trimToSizeByDateAsync:self->_byteLimit block:nil];
         } else {
             fileURL = nil;
         }
@@ -1350,57 +1350,57 @@ static NSURL *_sharedTrashURL;
 
 - (void)lockFileAccessWhileExecutingBlock:(nullable PINCacheBlock)block
 {
-    [self asyncLockFileAccessWhileExecutingBlock:block];
+    [self lockFileAccessWhileExecutingBlockAsync:block];
 }
 
 - (void)containsObjectForKey:(NSString *)key block:(PINDiskCacheContainsBlock)block
 {
-    [self asyncContainsObjectForKey:key block:block];
+    [self containsObjectForKeyAsync:key block:block];
 }
 
 - (void)objectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block
 {
-    [self asyncObjectForKey:key block:block];
+    [self objectForKeyAsync:key block:block];
 }
 
 - (void)fileURLForKey:(NSString *)key block:(nullable PINDiskCacheFileURLBlock)block
 {
-    [self asyncFileURLForKey:key block:block];
+    [self fileURLForKeyAsync:key block:block];
 }
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block
 {
-    [self asyncSetObject:object forKey:key block:block];
+    [self setObjectAsync:object forKey:key block:block];
 }
 
 - (void)removeObjectForKey:(NSString *)key block:(nullable PINDiskCacheObjectBlock)block
 {
-    [self asyncRemoveObjectForKey:key block:block];
+    [self removeObjectForKeyAsync:key block:block];
 }
 
 - (void)trimToDate:(NSDate *)date block:(nullable PINDiskCacheBlock)block
 {
-    [self asyncTrimToDate:date block:block];
+    [self trimToDateAsync:date block:block];
 }
 
 - (void)trimToSize:(NSUInteger)byteCount block:(nullable PINDiskCacheBlock)block
 {
-    [self asyncTrimToSize:byteCount block:block];
+    [self trimToSizeAsync:byteCount block:block];
 }
 
 - (void)trimToSizeByDate:(NSUInteger)byteCount block:(nullable PINDiskCacheBlock)block
 {
-    [self asyncTrimToSize:byteCount block:block];
+    [self trimToSizeAsync:byteCount block:block];
 }
 
 - (void)removeAllObjects:(nullable PINDiskCacheBlock)block
 {
-    [self asyncRemoveAllObjects:block];
+    [self removeAllObjectsAsync:block];
 }
 
 - (void)enumerateObjectsWithBlock:(PINDiskCacheFileURLBlock)block completionBlock:(nullable PINDiskCacheBlock)completionBlock
 {
-    [self asyncEnumerateObjectsWithBlock:block completionBlock:completionBlock];
+    [self enumerateObjectsWithBlockAsync:block completionBlock:completionBlock];
 }
 
 @end

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -613,7 +613,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)containsObjectForKey:(NSString *)key block:(PINDiskCacheContainsBlock)block
+- (void)asyncContainsObjectForKey:(NSString *)key block:(PINDiskCacheContainsBlock)block
 {
     if (!key || !block)
         return;
@@ -626,7 +626,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)objectForKey:(NSString *)key block:(PINDiskCacheObjectBlock)block
+- (void)asyncObjectForKey:(NSString *)key block:(PINDiskCacheObjectBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -641,7 +641,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)fileURLForKey:(NSString *)key block:(PINDiskCacheFileURLBlock)block
+- (void)asyncFileURLForKey:(NSString *)key block:(PINDiskCacheFileURLBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -657,7 +657,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(PINDiskCacheObjectBlock)block
+- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key block:(PINDiskCacheObjectBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -672,12 +672,12 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block
+- (void)asyncSetObject:(id <NSCoding>)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINCacheObjectBlock)block
 {
-    [self setObject:object forKey:key block:(PINDiskCacheObjectBlock)block];
+    [self asyncSetObject:object forKey:key block:(PINDiskCacheObjectBlock)block];
 }
 
-- (void)removeObjectForKey:(NSString *)key block:(PINDiskCacheObjectBlock)block
+- (void)asyncRemoveObjectForKey:(NSString *)key block:(PINDiskCacheObjectBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -692,7 +692,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)trimToSize:(NSUInteger)trimByteCount block:(PINCacheBlock)block
+- (void)asyncTrimToSize:(NSUInteger)trimByteCount block:(PINCacheBlock)block
 {
     PINOperationBlock operation = ^(id data) {
         [self trimToSize:((NSNumber *)data).unsignedIntegerValue];
@@ -713,7 +713,7 @@ static NSURL *_sharedTrashURL;
                            completion:completion];
 }
 
-- (void)trimToDate:(NSDate *)trimDate block:(PINCacheBlock)block
+- (void)asyncTrimToDate:(NSDate *)trimDate block:(PINCacheBlock)block
 {
     PINOperationBlock operation = ^(id data){
         [self trimToDate:(NSDate *)data];
@@ -734,7 +734,7 @@ static NSURL *_sharedTrashURL;
                            completion:completion];
 }
 
-- (void)trimToSizeByDate:(NSUInteger)trimByteCount block:(PINCacheBlock)block
+- (void)asyncTrimToSizeByDate:(NSUInteger)trimByteCount block:(PINCacheBlock)block
 {
     PINOperationBlock operation = ^(id data){
         [self trimToSizeByDate:((NSNumber *)data).unsignedIntegerValue];
@@ -755,7 +755,7 @@ static NSURL *_sharedTrashURL;
                            completion:completion];
 }
 
-- (void)removeAllObjects:(PINCacheBlock)block
+- (void)asyncRemoveAllObjects:(PINCacheBlock)block
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -769,7 +769,7 @@ static NSURL *_sharedTrashURL;
     } withPriority:PINOperationQueuePriorityLow];
 }
 
-- (void)enumerateObjectsWithBlock:(PINDiskCacheFileURLBlock)block completionBlock:(PINCacheBlock)completionBlock
+- (void)asyncEnumerateObjectsWithBlock:(PINDiskCacheFileURLBlock)block completionBlock:(PINCacheBlock)completionBlock
 {
     __weak PINDiskCache *weakSelf = self;
     
@@ -946,7 +946,7 @@ static NSURL *_sharedTrashURL;
             }
             
             if (self->_byteLimit > 0 && self->_byteCount > self->_byteLimit)
-                [self trimToSizeByDate:self->_byteLimit block:nil];
+                [self asyncTrimToSizeByDate:self->_byteLimit block:nil];
         } else {
             fileURL = nil;
         }

--- a/Source/PINMemoryCache.h
+++ b/Source/PINMemoryCache.h
@@ -156,7 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param cost The total accumulation allowed to remain after the cache has been trimmed.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)trimToCostAsync:(NSUInteger)cost block:(nullable PINCacheBlock)block;
+- (void)trimToCostAsync:(NSUInteger)cost completion:(nullable PINCacheBlock)block;
 
 /**
  Removes objects from the cache, ordered by date (least recently used first), until the <totalCost> is below
@@ -166,7 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param cost The total accumulation allowed to remain after the cache has been trimmed.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)trimToCostByDateAsync:(NSUInteger)cost block:(nullable PINCacheBlock)block;
+- (void)trimToCostByDateAsync:(NSUInteger)cost completion:(nullable PINCacheBlock)block;
 
 /**
  Loops through all objects in the cache with reads and writes suspended. Calling serial methods which

--- a/Source/PINMemoryCache.h
+++ b/Source/PINMemoryCache.h
@@ -156,7 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param cost The total accumulation allowed to remain after the cache has been trimmed.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)asyncTrimToCost:(NSUInteger)cost block:(nullable PINCacheBlock)block;
+- (void)trimToCostAsync:(NSUInteger)cost block:(nullable PINCacheBlock)block;
 
 /**
  Removes objects from the cache, ordered by date (least recently used first), until the <totalCost> is below
@@ -166,7 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param cost The total accumulation allowed to remain after the cache has been trimmed.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)asyncTrimToCostByDate:(NSUInteger)cost block:(nullable PINCacheBlock)block;
+- (void)trimToCostByDateAsync:(NSUInteger)cost block:(nullable PINCacheBlock)block;
 
 /**
  Loops through all objects in the cache with reads and writes suspended. Calling serial methods which
@@ -175,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param block A block to be executed for every object in the cache.
  @param completionBlock An optional block to be executed concurrently when the enumeration is complete.
  */
-- (void)asyncEnumerateObjectsWithBlock:(PINCacheObjectBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
+- (void)enumerateObjectsWithBlockAsync:(PINCacheObjectBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
 
 #pragma mark - Synchronous Methods
 /// @name Synchronous Methods

--- a/Source/PINMemoryCache.h
+++ b/Source/PINMemoryCache.h
@@ -184,6 +184,7 @@ NS_ASSUME_NONNULL_BEGIN
  Removes objects from the cache, costliest objects first, until the <totalCost> is below the specified
  value. This method blocks the calling thread until the cache has been trimmed.
  
+ @see trimToCostAsync:
  @param cost The total accumulation allowed to remain after the cache has been trimmed.
  */
 - (void)trimToCost:(NSUInteger)cost;
@@ -192,6 +193,7 @@ NS_ASSUME_NONNULL_BEGIN
  Removes objects from the cache, ordered by date (least recently used first), until the <totalCost> is below
  the specified value. This method blocks the calling thread until the cache has been trimmed.
  
+ @see trimToCostByDateAsync:
  @param cost The total accumulation allowed to remain after the cache has been trimmed.
  */
 - (void)trimToCostByDate:(NSUInteger)cost;
@@ -201,6 +203,7 @@ NS_ASSUME_NONNULL_BEGIN
  This method blocks the calling thread until all objects have been enumerated.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  
+ @see enumerateObjectsWithBlockAsync:completionBlock:
  @param block A block to be executed for every object in the cache.
  
  @warning Do not call this method within the event blocks (<didReceiveMemoryWarningBlock>, etc.)

--- a/Source/PINMemoryCache.h
+++ b/Source/PINMemoryCache.h
@@ -4,27 +4,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import "PINCaching.h"
 #import "PINCacheObjectSubscripting.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class PINMemoryCache;
 @class PINOperationQueue;
-
-/**
- A callback block which provides only the cache as an argument
- */
-typedef void (^PINMemoryCacheBlock)(PINMemoryCache *cache);
-
-/**
- A callback block which provides the cache, key and object as arguments
- */
-typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, id __nullable object);
-
-/**
- A callback block which provides a BOOL value as argument
- */
-typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
 
 
 /**
@@ -44,9 +30,9 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  a memory cache backed by a disk cache.
  */
 
-@interface PINMemoryCache : NSObject <PINCacheObjectSubscripting>
+@interface PINMemoryCache : NSObject <PINCaching, PINCacheObjectSubscripting>
 
-#pragma mark -
+#pragma mark - Properties
 /// @name Core
 
 /**
@@ -88,7 +74,7 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  */
 @property (assign) BOOL removeAllObjectsOnEnteringBackground;
 
-#pragma mark -
+#pragma mark - Event Blocks
 /// @name Event Blocks
 
 /**
@@ -96,56 +82,56 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheObjectBlock __nullable willAddObjectBlock;
+@property (copy) PINCacheObjectBlock __nullable willAddObjectBlock;
 
 /**
  A block to be executed just before an object is removed from the cache. This block will be excuted
  within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheObjectBlock __nullable willRemoveObjectBlock;
+@property (copy) PINCacheObjectBlock __nullable willRemoveObjectBlock;
 
 /**
  A block to be executed just before all objects are removed from the cache as a result of <removeAllObjects:>.
  This block will be excuted within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheBlock __nullable willRemoveAllObjectsBlock;
+@property (copy) PINCacheBlock __nullable willRemoveAllObjectsBlock;
 
 /**
  A block to be executed just after an object is added to the cache. This block will be excuted within
  a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheObjectBlock __nullable didAddObjectBlock;
+@property (copy) PINCacheObjectBlock __nullable didAddObjectBlock;
 
 /**
  A block to be executed just after an object is removed from the cache. This block will be excuted
  within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheObjectBlock __nullable didRemoveObjectBlock;
+@property (copy) PINCacheObjectBlock __nullable didRemoveObjectBlock;
 
 /**
  A block to be executed just after all objects are removed from the cache as a result of <removeAllObjects:>.
  This block will be excuted within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINMemoryCacheBlock __nullable didRemoveAllObjectsBlock;
+@property (copy) PINCacheBlock __nullable didRemoveAllObjectsBlock;
 
 /**
  A block to be executed upon receiving a memory warning (iOS only) potentially in parallel with other blocks on the <queue>.
  This block will be executed regardless of the value of <removeAllObjectsOnMemoryWarning>. Defaults to `nil`.
  */
-@property (copy) PINMemoryCacheBlock __nullable didReceiveMemoryWarningBlock;
+@property (copy) PINCacheBlock __nullable didReceiveMemoryWarningBlock;
 
 /**
  A block to be executed when the app enters the background (iOS only) potentially in parallel with other blocks on the <concurrentQueue>.
  This block will be executed regardless of the value of <removeAllObjectsOnEnteringBackground>. Defaults to `nil`.
  */
-@property (copy) PINMemoryCacheBlock __nullable didEnterBackgroundBlock;
+@property (copy) PINCacheBlock __nullable didEnterBackgroundBlock;
 
-#pragma mark -
+#pragma mark - Lifecycle
 /// @name Shared Cache
 
 /**
@@ -155,72 +141,12 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  */
 + (instancetype)sharedCache;
 
-- (instancetype)initWithOperationQueue:(PINOperationQueue *)operationQueue NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithOperationQueue:(PINOperationQueue *)operationQueue;
 
-#pragma mark -
+- (instancetype)initWithName:(NSString *)name operationQueue:(PINOperationQueue *)operationQueue NS_DESIGNATED_INITIALIZER;
+
+#pragma mark - Asynchronous Methods
 /// @name Asynchronous Methods
-
-/**
- This method determines whether an object is present for the given key in the cache. This method returns immediately
- and executes the passed block after the object is available, potentially in parallel with other blocks on the
- <concurrentQueue>.
- 
- @see containsObjectForKey:
- @param key The key associated with the object.
- @param block A block to be executed concurrently after the containment check happened
- */
-- (void)containsObjectForKey:(NSString *)key block:(PINMemoryCacheContainmentBlock)block;
-
-/**
- Retrieves the object for the specified key. This method returns immediately and executes the passed
- block after the object is available, potentially in parallel with other blocks on the <concurrentQueue>.
- 
- @param key The key associated with the requested object.
- @param block A block to be executed concurrently when the object is available.
- */
-- (void)objectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block;
-
-/**
- Stores an object in the cache for the specified key. This method returns immediately and executes the
- passed block after the object has been stored, potentially in parallel with other blocks on the <concurrentQueue>.
- 
- @param object An object to store in the cache.
- @param key A key to associate with the object. This string will be copied.
- @param block A block to be executed concurrently after the object has been stored, or nil.
- */
-- (void)setObject:(id)object forKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block;
-
-/**
- Stores an object in the cache for the specified key and the specified cost. If the cost causes the total
- to go over the <costLimit> the cache is trimmed (oldest objects first). This method returns immediately
- and executes the passed block after the object has been stored, potentially in parallel with other blocks
- on the <concurrentQueue>.
- 
- @param object An object to store in the cache.
- @param key A key to associate with the object. This string will be copied.
- @param cost An amount to add to the <totalCost>.
- @param block A block to be executed concurrently after the object has been stored, or nil.
- */
-- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINMemoryCacheObjectBlock)block;
-
-/**
- Removes the object for the specified key. This method returns immediately and executes the passed
- block after the object has been removed, potentially in parallel with other blocks on the <concurrentQueue>.
- 
- @param key The key associated with the object to be removed.
- @param block A block to be executed concurrently after the object has been removed, or nil.
- */
-- (void)removeObjectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block;
-
-/**
- Removes all objects from the cache that have not been used since the specified date.
- This method returns immediately and executes the passed block after the cache has been trimmed,
- potentially in parallel with other blocks on the <concurrentQueue>.
- 
- @param date Objects that haven't been accessed since this date are removed from the cache.
- @param block A block to be executed concurrently after the cache has been trimmed, or nil.
- */
-- (void)trimToDate:(NSDate *)date block:(nullable PINMemoryCacheBlock)block;
 
 /**
  Removes objects from the cache, costliest objects first, until the <totalCost> is below the specified
@@ -230,7 +156,7 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  @param cost The total accumulation allowed to remain after the cache has been trimmed.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)trimToCost:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block;
+- (void)trimToCost:(NSUInteger)cost block:(nullable PINCacheBlock)block;
 
 /**
  Removes objects from the cache, ordered by date (least recently used first), until the <totalCost> is below
@@ -240,15 +166,7 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  @param cost The total accumulation allowed to remain after the cache has been trimmed.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)trimToCostByDate:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block;
-
-/**
- Removes all objects from the cache. This method returns immediately and executes the passed block after
- the cache has been cleared, potentially in parallel with other blocks on the <concurrentQueue>.
- 
- @param block A block to be executed concurrently after the cache has been cleared, or nil.
- */
-- (void)removeAllObjects:(nullable PINMemoryCacheBlock)block;
+- (void)trimToCostByDate:(NSUInteger)cost block:(nullable PINCacheBlock)block;
 
 /**
  Loops through all objects in the cache with reads and writes suspended. Calling serial methods which
@@ -257,66 +175,10 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  @param block A block to be executed for every object in the cache.
  @param completionBlock An optional block to be executed concurrently when the enumeration is complete.
  */
-- (void)enumerateObjectsWithBlock:(PINMemoryCacheObjectBlock)block completionBlock:(nullable PINMemoryCacheBlock)completionBlock;
+- (void)enumerateObjectsWithBlock:(PINCacheObjectBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
 
-#pragma mark -
+#pragma mark - Synchronous Methods
 /// @name Synchronous Methods
-
-/**
- This method determines whether an object is present for the given key in the cache.
- 
- @see containsObjectForKey:block:
- @param key The key associated with the object.
- @result YES if an object is present for the given key in the cache, otherwise NO.
- */
-- (BOOL)containsObjectForKey:(NSString *)key;
-
-/**
- Retrieves the object for the specified key. This method blocks the calling thread until the
- object is available.
- 
- @see objectForKey:block:
- @param key The key associated with the object.
- @result The object for the specified key.
- */
-- (__nullable id)objectForKey:(nullable NSString *)key;
-
-/**
- Stores an object in the cache for the specified key. This method blocks the calling thread until the object
- has been set.
- 
- @see setObject:forKey:block:
- @param object An object to store in the cache.
- @param key A key to associate with the object. This string will be copied.
- */
-- (void)setObject:(id)object forKey:(NSString *)key;
-
-/**
- Stores an object in the cache for the specified key and the specified cost. If the cost causes the total
- to go over the <costLimit> the cache is trimmed (oldest objects first). This method blocks the calling thread
- until the object has been stored.
- 
- @param object An object to store in the cache.
- @param key A key to associate with the object. This string will be copied.
- @param cost An amount to add to the <totalCost>.
- */
-- (void)setObject:(nullable id)object forKey:(nullable NSString *)key withCost:(NSUInteger)cost;
-
-/**
- Removes the object for the specified key. This method blocks the calling thread until the object
- has been removed.
- 
- @param key The key associated with the object to be removed.
- */
-- (void)removeObjectForKey:(nullable NSString *)key;
-
-/**
- Removes all objects from the cache that have not been used since the specified date.
- This method blocks the calling thread until the cache has been trimmed.
- 
- @param date Objects that haven't been accessed since this date are removed from the cache.
- */
-- (void)trimToDate:(nullable NSDate *)date;
 
 /**
  Removes objects from the cache, costliest objects first, until the <totalCost> is below the specified
@@ -335,11 +197,6 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
 - (void)trimToCostByDate:(NSUInteger)cost;
 
 /**
- Removes all objects from the cache. This method blocks the calling thread until the cache has been cleared.
- */
-- (void)removeAllObjects;
-
-/**
  Loops through all objects in the cache within a memory lock (reads and writes are suspended during the enumeration).
  This method blocks the calling thread until all objects have been enumerated.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
@@ -350,7 +207,7 @@ typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
  Instead use the asynchronous version, <enumerateObjectsWithBlock:completionBlock:>.
  
  */
-- (void)enumerateObjectsWithBlock:(nullable PINMemoryCacheObjectBlock)block;
+- (void)enumerateObjectsWithBlock:(nullable PINCacheObjectBlock)block;
 
 @end
 

--- a/Source/PINMemoryCache.h
+++ b/Source/PINMemoryCache.h
@@ -4,8 +4,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "PINCaching.h"
-#import "PINCacheObjectSubscripting.h"
+#import <PINCache/PINCaching.h>
+#import <PINCache/PINCacheObjectSubscripting.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -82,54 +82,54 @@ NS_ASSUME_NONNULL_BEGIN
  a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINCacheObjectBlock __nullable willAddObjectBlock;
+@property (nullable, copy) PINCacheObjectBlock willAddObjectBlock;
 
 /**
  A block to be executed just before an object is removed from the cache. This block will be excuted
  within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINCacheObjectBlock __nullable willRemoveObjectBlock;
+@property (nullable, copy) PINCacheObjectBlock willRemoveObjectBlock;
 
 /**
  A block to be executed just before all objects are removed from the cache as a result of <removeAllObjects:>.
  This block will be excuted within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINCacheBlock __nullable willRemoveAllObjectsBlock;
+@property (nullable, copy) PINCacheBlock willRemoveAllObjectsBlock;
 
 /**
  A block to be executed just after an object is added to the cache. This block will be excuted within
  a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINCacheObjectBlock __nullable didAddObjectBlock;
+@property (nullable, copy) PINCacheObjectBlock didAddObjectBlock;
 
 /**
  A block to be executed just after an object is removed from the cache. This block will be excuted
  within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINCacheObjectBlock __nullable didRemoveObjectBlock;
+@property (nullable, copy) PINCacheObjectBlock didRemoveObjectBlock;
 
 /**
  A block to be executed just after all objects are removed from the cache as a result of <removeAllObjects:>.
  This block will be excuted within a lock, i.e. all reads and writes are suspended for the duration of the block.
  Calling synchronous methods on the cache within this callback will likely cause a deadlock.
  */
-@property (copy) PINCacheBlock __nullable didRemoveAllObjectsBlock;
+@property (nullable, copy) PINCacheBlock didRemoveAllObjectsBlock;
 
 /**
  A block to be executed upon receiving a memory warning (iOS only) potentially in parallel with other blocks on the <queue>.
  This block will be executed regardless of the value of <removeAllObjectsOnMemoryWarning>. Defaults to `nil`.
  */
-@property (copy) PINCacheBlock __nullable didReceiveMemoryWarningBlock;
+@property (nullable, copy) PINCacheBlock didReceiveMemoryWarningBlock;
 
 /**
  A block to be executed when the app enters the background (iOS only) potentially in parallel with other blocks on the <concurrentQueue>.
  This block will be executed regardless of the value of <removeAllObjectsOnEnteringBackground>. Defaults to `nil`.
  */
-@property (copy) PINCacheBlock __nullable didEnterBackgroundBlock;
+@property (nullable, copy) PINCacheBlock didEnterBackgroundBlock;
 
 #pragma mark - Lifecycle
 /// @name Shared Cache

--- a/Source/PINMemoryCache.h
+++ b/Source/PINMemoryCache.h
@@ -211,4 +211,24 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+
+#pragma mark - Deprecated
+
+typedef void (^PINMemoryCacheBlock)(PINMemoryCache *cache);
+typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, id __nullable object);
+typedef void (^PINMemoryCacheContainmentBlock)(BOOL containsObject);
+
+@interface PINMemoryCache (Deprecated)
+- (void)containsObjectForKey:(NSString *)key block:(PINMemoryCacheContainmentBlock)block __attribute__((deprecated));
+- (void)objectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block __attribute__((deprecated));
+- (void)setObject:(id)object forKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block __attribute__((deprecated));
+- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINMemoryCacheObjectBlock)block __attribute__((deprecated));
+- (void)removeObjectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block __attribute__((deprecated));
+- (void)trimToDate:(NSDate *)date block:(nullable PINMemoryCacheBlock)block __attribute__((deprecated));
+- (void)trimToCost:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block __attribute__((deprecated));
+- (void)trimToCostByDate:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block __attribute__((deprecated));
+- (void)removeAllObjects:(nullable PINMemoryCacheBlock)block __attribute__((deprecated));
+- (void)enumerateObjectsWithBlock:(PINMemoryCacheObjectBlock)block completionBlock:(nullable PINMemoryCacheBlock)completionBlock __attribute__((deprecated));
+@end
+
 NS_ASSUME_NONNULL_END

--- a/Source/PINMemoryCache.h
+++ b/Source/PINMemoryCache.h
@@ -156,7 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param cost The total accumulation allowed to remain after the cache has been trimmed.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)trimToCost:(NSUInteger)cost block:(nullable PINCacheBlock)block;
+- (void)asyncTrimToCost:(NSUInteger)cost block:(nullable PINCacheBlock)block;
 
 /**
  Removes objects from the cache, ordered by date (least recently used first), until the <totalCost> is below
@@ -166,7 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param cost The total accumulation allowed to remain after the cache has been trimmed.
  @param block A block to be executed concurrently after the cache has been trimmed, or nil.
  */
-- (void)trimToCostByDate:(NSUInteger)cost block:(nullable PINCacheBlock)block;
+- (void)asyncTrimToCostByDate:(NSUInteger)cost block:(nullable PINCacheBlock)block;
 
 /**
  Loops through all objects in the cache with reads and writes suspended. Calling serial methods which
@@ -175,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param block A block to be executed for every object in the cache.
  @param completionBlock An optional block to be executed concurrently when the enumeration is complete.
  */
-- (void)enumerateObjectsWithBlock:(PINCacheObjectBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
+- (void)asyncEnumerateObjectsWithBlock:(PINCacheObjectBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
 
 #pragma mark - Synchronous Methods
 /// @name Synchronous Methods

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -12,8 +12,10 @@
 #endif
 
 static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
+static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 
 @interface PINMemoryCache ()
+@property (copy, nonatomic) NSString *name;
 @property (strong, nonatomic) PINOperationQueue *operationQueue;
 @property (assign, nonatomic) pthread_mutex_t mutex;
 @property (strong, nonatomic) NSMutableDictionary *dictionary;
@@ -23,6 +25,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 
 @implementation PINMemoryCache
 
+@synthesize name = _name;
 @synthesize ageLimit = _ageLimit;
 @synthesize costLimit = _costLimit;
 @synthesize totalCost = _totalCost;
@@ -53,44 +56,50 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 
 - (instancetype)initWithOperationQueue:(PINOperationQueue *)operationQueue
 {
+    return [self initWithName:PINMemoryCacheSharedName operationQueue:operationQueue];
+}
+
+- (instancetype)initWithName:(NSString *)name operationQueue:(PINOperationQueue *)operationQueue
+{
     if (self = [super init]) {
         __unused int result = pthread_mutex_init(&_mutex, NULL);
         NSAssert(result == 0, @"Failed to init lock in PINMemoryCache %@. Code: %d", self, result);
-
+        
+        _name = [name copy];
         _operationQueue = operationQueue;
-
+        
         _dictionary = [[NSMutableDictionary alloc] init];
         _dates = [[NSMutableDictionary alloc] init];
         _costs = [[NSMutableDictionary alloc] init];
-
+        
         _willAddObjectBlock = nil;
         _willRemoveObjectBlock = nil;
         _willRemoveAllObjectsBlock = nil;
-
+        
         _didAddObjectBlock = nil;
         _didRemoveObjectBlock = nil;
         _didRemoveAllObjectsBlock = nil;
-
+        
         _didReceiveMemoryWarningBlock = nil;
         _didEnterBackgroundBlock = nil;
-
+        
         _ageLimit = 0.0;
         _costLimit = 0;
         _totalCost = 0;
-
+        
         _removeAllObjectsOnMemoryWarning = YES;
         _removeAllObjectsOnEnteringBackground = YES;
-
+        
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !TARGET_OS_WATCH
-      [[NSNotificationCenter defaultCenter] addObserver:self
-                                               selector:@selector(didReceiveEnterBackgroundNotification:)
-                                                   name:UIApplicationDidEnterBackgroundNotification
-                                                 object:nil];
-      [[NSNotificationCenter defaultCenter] addObserver:self
-                                               selector:@selector(didReceiveMemoryWarningNotification:)
-                                                   name:UIApplicationDidReceiveMemoryWarningNotification
-                                                 object:nil];
-
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(didReceiveEnterBackgroundNotification:)
+                                                     name:UIApplicationDidEnterBackgroundNotification
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(didReceiveMemoryWarningNotification:)
+                                                     name:UIApplicationDidReceiveMemoryWarningNotification
+                                                   object:nil];
+        
 #endif
     }
     return self;
@@ -123,7 +132,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
         }
         
         [strongSelf lock];
-        PINMemoryCacheBlock didReceiveMemoryWarningBlock = strongSelf->_didReceiveMemoryWarningBlock;
+        PINCacheBlock didReceiveMemoryWarningBlock = strongSelf->_didReceiveMemoryWarningBlock;
         [strongSelf unlock];
         
         if (didReceiveMemoryWarningBlock)
@@ -145,7 +154,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
         }
 
         [strongSelf lock];
-            PINMemoryCacheBlock didEnterBackgroundBlock = strongSelf->_didEnterBackgroundBlock;
+            PINCacheBlock didEnterBackgroundBlock = strongSelf->_didEnterBackgroundBlock;
         [strongSelf unlock];
 
         if (didEnterBackgroundBlock)
@@ -158,8 +167,8 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     [self lock];
         id object = _dictionary[key];
         NSNumber *cost = _costs[key];
-        PINMemoryCacheObjectBlock willRemoveObjectBlock = _willRemoveObjectBlock;
-        PINMemoryCacheObjectBlock didRemoveObjectBlock = _didRemoveObjectBlock;
+        PINCacheObjectBlock willRemoveObjectBlock = _willRemoveObjectBlock;
+        PINCacheObjectBlock didRemoveObjectBlock = _didRemoveObjectBlock;
     [self unlock];
 
     if (willRemoveObjectBlock)
@@ -273,7 +282,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 
 #pragma mark - Public Asynchronous Methods -
 
-- (void)containsObjectForKey:(NSString *)key block:(PINMemoryCacheContainmentBlock)block
+- (void)containsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block
 {
     if (!key || !block)
         return;
@@ -288,7 +297,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)objectForKey:(NSString *)key block:(PINMemoryCacheObjectBlock)block
+- (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -301,12 +310,12 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)setObject:(id)object forKey:(NSString *)key block:(PINMemoryCacheObjectBlock)block
+- (void)setObject:(id)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
     [self setObject:object forKey:key withCost:0 block:block];
 }
 
-- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINMemoryCacheObjectBlock)block
+- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -319,7 +328,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)removeObjectForKey:(NSString *)key block:(PINMemoryCacheObjectBlock)block
+- (void)removeObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -332,7 +341,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)trimToDate:(NSDate *)trimDate block:(PINMemoryCacheBlock)block
+- (void)trimToDate:(NSDate *)trimDate block:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -345,7 +354,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)trimToCost:(NSUInteger)cost block:(PINMemoryCacheBlock)block
+- (void)trimToCost:(NSUInteger)cost block:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -358,7 +367,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)trimToCostByDate:(NSUInteger)cost block:(PINMemoryCacheBlock)block
+- (void)trimToCostByDate:(NSUInteger)cost block:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -371,7 +380,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)removeAllObjects:(PINMemoryCacheBlock)block
+- (void)removeAllObjects:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -384,7 +393,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)enumerateObjectsWithBlock:(PINMemoryCacheObjectBlock)block completionBlock:(PINMemoryCacheBlock)completionBlock
+- (void)enumerateObjectsWithBlock:(PINCacheObjectBlock)block completionBlock:(PINCacheBlock)completionBlock
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -454,8 +463,8 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
         return;
     
     [self lock];
-        PINMemoryCacheObjectBlock willAddObjectBlock = _willAddObjectBlock;
-        PINMemoryCacheObjectBlock didAddObjectBlock = _didAddObjectBlock;
+        PINCacheObjectBlock willAddObjectBlock = _willAddObjectBlock;
+        PINCacheObjectBlock didAddObjectBlock = _didAddObjectBlock;
         NSUInteger costLimit = _costLimit;
     [self unlock];
     
@@ -515,8 +524,8 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 - (void)removeAllObjects
 {
     [self lock];
-        PINMemoryCacheBlock willRemoveAllObjectsBlock = _willRemoveAllObjectsBlock;
-        PINMemoryCacheBlock didRemoveAllObjectsBlock = _didRemoveAllObjectsBlock;
+        PINCacheBlock willRemoveAllObjectsBlock = _willRemoveAllObjectsBlock;
+        PINCacheBlock didRemoveAllObjectsBlock = _didRemoveAllObjectsBlock;
     [self unlock];
     
     if (willRemoveAllObjectsBlock)
@@ -535,7 +544,7 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
     
 }
 
-- (void)enumerateObjectsWithBlock:(PINMemoryCacheObjectBlock)block
+- (void)enumerateObjectsWithBlock:(PINCacheObjectBlock)block
 {
     if (!block)
         return;
@@ -555,128 +564,128 @@ static NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 
 #pragma mark - Public Thread Safe Accessors -
 
-- (PINMemoryCacheObjectBlock)willAddObjectBlock
+- (PINCacheObjectBlock)willAddObjectBlock
 {
     [self lock];
-        PINMemoryCacheObjectBlock block = _willAddObjectBlock;
+        PINCacheObjectBlock block = _willAddObjectBlock;
     [self unlock];
 
     return block;
 }
 
-- (void)setWillAddObjectBlock:(PINMemoryCacheObjectBlock)block
+- (void)setWillAddObjectBlock:(PINCacheObjectBlock)block
 {
     [self lock];
         _willAddObjectBlock = [block copy];
     [self unlock];
 }
 
-- (PINMemoryCacheObjectBlock)willRemoveObjectBlock
+- (PINCacheObjectBlock)willRemoveObjectBlock
 {
     [self lock];
-        PINMemoryCacheObjectBlock block = _willRemoveObjectBlock;
+        PINCacheObjectBlock block = _willRemoveObjectBlock;
     [self unlock];
 
     return block;
 }
 
-- (void)setWillRemoveObjectBlock:(PINMemoryCacheObjectBlock)block
+- (void)setWillRemoveObjectBlock:(PINCacheObjectBlock)block
 {
     [self lock];
         _willRemoveObjectBlock = [block copy];
     [self unlock];
 }
 
-- (PINMemoryCacheBlock)willRemoveAllObjectsBlock
+- (PINCacheBlock)willRemoveAllObjectsBlock
 {
     [self lock];
-        PINMemoryCacheBlock block = _willRemoveAllObjectsBlock;
+        PINCacheBlock block = _willRemoveAllObjectsBlock;
     [self unlock];
 
     return block;
 }
 
-- (void)setWillRemoveAllObjectsBlock:(PINMemoryCacheBlock)block
+- (void)setWillRemoveAllObjectsBlock:(PINCacheBlock)block
 {
     [self lock];
         _willRemoveAllObjectsBlock = [block copy];
     [self unlock];
 }
 
-- (PINMemoryCacheObjectBlock)didAddObjectBlock
+- (PINCacheObjectBlock)didAddObjectBlock
 {
     [self lock];
-        PINMemoryCacheObjectBlock block = _didAddObjectBlock;
+        PINCacheObjectBlock block = _didAddObjectBlock;
     [self unlock];
 
     return block;
 }
 
-- (void)setDidAddObjectBlock:(PINMemoryCacheObjectBlock)block
+- (void)setDidAddObjectBlock:(PINCacheObjectBlock)block
 {
     [self lock];
         _didAddObjectBlock = [block copy];
     [self unlock];
 }
 
-- (PINMemoryCacheObjectBlock)didRemoveObjectBlock
+- (PINCacheObjectBlock)didRemoveObjectBlock
 {
     [self lock];
-        PINMemoryCacheObjectBlock block = _didRemoveObjectBlock;
+        PINCacheObjectBlock block = _didRemoveObjectBlock;
     [self unlock];
 
     return block;
 }
 
-- (void)setDidRemoveObjectBlock:(PINMemoryCacheObjectBlock)block
+- (void)setDidRemoveObjectBlock:(PINCacheObjectBlock)block
 {
     [self lock];
         _didRemoveObjectBlock = [block copy];
     [self unlock];
 }
 
-- (PINMemoryCacheBlock)didRemoveAllObjectsBlock
+- (PINCacheBlock)didRemoveAllObjectsBlock
 {
     [self lock];
-        PINMemoryCacheBlock block = _didRemoveAllObjectsBlock;
+        PINCacheBlock block = _didRemoveAllObjectsBlock;
     [self unlock];
 
     return block;
 }
 
-- (void)setDidRemoveAllObjectsBlock:(PINMemoryCacheBlock)block
+- (void)setDidRemoveAllObjectsBlock:(PINCacheBlock)block
 {
     [self lock];
         _didRemoveAllObjectsBlock = [block copy];
     [self unlock];
 }
 
-- (PINMemoryCacheBlock)didReceiveMemoryWarningBlock
+- (PINCacheBlock)didReceiveMemoryWarningBlock
 {
     [self lock];
-        PINMemoryCacheBlock block = _didReceiveMemoryWarningBlock;
+        PINCacheBlock block = _didReceiveMemoryWarningBlock;
     [self unlock];
 
     return block;
 }
 
-- (void)setDidReceiveMemoryWarningBlock:(PINMemoryCacheBlock)block
+- (void)setDidReceiveMemoryWarningBlock:(PINCacheBlock)block
 {
     [self lock];
         _didReceiveMemoryWarningBlock = [block copy];
     [self unlock];
 }
 
-- (PINMemoryCacheBlock)didEnterBackgroundBlock
+- (PINCacheBlock)didEnterBackgroundBlock
 {
     [self lock];
-        PINMemoryCacheBlock block = _didEnterBackgroundBlock;
+        PINCacheBlock block = _didEnterBackgroundBlock;
     [self unlock];
 
     return block;
 }
 
-- (void)setDidEnterBackgroundBlock:(PINMemoryCacheBlock)block
+- (void)setDidEnterBackgroundBlock:(PINCacheBlock)block
 {
     [self lock];
         _didEnterBackgroundBlock = [block copy];

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -121,7 +121,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 
 - (void)didReceiveMemoryWarningNotification:(NSNotification *)notification {
     if (self.removeAllObjectsOnMemoryWarning)
-        [self removeAllObjects:nil];
+        [self asyncRemoveAllObjects:nil];
 
     __weak PINMemoryCache *weakSelf = self;
 
@@ -143,7 +143,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 - (void)didReceiveEnterBackgroundNotification:(NSNotification *)notification
 {
     if (self.removeAllObjectsOnEnteringBackground)
-        [self removeAllObjects:nil];
+        [self asyncRemoveAllObjects:nil];
 
     __weak PINMemoryCache *weakSelf = self;
 
@@ -282,7 +282,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 
 #pragma mark - Public Asynchronous Methods -
 
-- (void)containsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block
+- (void)asyncContainsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block
 {
     if (!key || !block)
         return;
@@ -297,7 +297,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)objectForKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)asyncObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -310,12 +310,12 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)setObject:(id)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)asyncSetObject:(id)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
-    [self setObject:object forKey:key withCost:0 block:block];
+    [self asyncSetObject:object forKey:key withCost:0 block:block];
 }
 
-- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
+- (void)asyncSetObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -328,7 +328,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)removeObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)asyncRemoveObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -341,7 +341,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)trimToDate:(NSDate *)trimDate block:(PINCacheBlock)block
+- (void)asyncTrimToDate:(NSDate *)trimDate block:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -354,7 +354,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)trimToCost:(NSUInteger)cost block:(PINCacheBlock)block
+- (void)asyncTrimToCost:(NSUInteger)cost block:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -367,7 +367,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)trimToCostByDate:(NSUInteger)cost block:(PINCacheBlock)block
+- (void)asyncTrimToCostByDate:(NSUInteger)cost block:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -380,7 +380,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)removeAllObjects:(PINCacheBlock)block
+- (void)asyncRemoveAllObjects:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -393,7 +393,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)enumerateObjectsWithBlock:(PINCacheObjectBlock)block completionBlock:(PINCacheBlock)completionBlock
+- (void)asyncEnumerateObjectsWithBlock:(PINCacheObjectBlock)block completionBlock:(PINCacheBlock)completionBlock
 {
     __weak PINMemoryCache *weakSelf = self;
     

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -282,7 +282,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 
 #pragma mark - Public Asynchronous Methods -
 
-- (void)containsObjectForKeyAsync:(NSString *)key block:(PINCacheObjectContainmentBlock)block
+- (void)containsObjectForKeyAsync:(NSString *)key completion:(PINCacheObjectContainmentBlock)block
 {
     if (!key || !block)
         return;
@@ -297,7 +297,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)objectForKeyAsync:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)objectForKeyAsync:(NSString *)key completion:(PINCacheObjectBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -309,12 +309,12 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)setObjectAsync:(id)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)setObjectAsync:(id)object forKey:(NSString *)key completion:(PINCacheObjectBlock)block
 {
-    [self setObjectAsync:object forKey:key withCost:0 block:block];
+    [self setObjectAsync:object forKey:key withCost:0 completion:block];
 }
 
-- (void)setObjectAsync:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
+- (void)setObjectAsync:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost completion:(PINCacheObjectBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -327,7 +327,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)removeObjectForKeyAsync:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)removeObjectForKeyAsync:(NSString *)key completion:(PINCacheObjectBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -340,7 +340,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)trimToDateAsync:(NSDate *)trimDate block:(PINCacheBlock)block
+- (void)trimToDateAsync:(NSDate *)trimDate completion:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -353,7 +353,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)trimToCostAsync:(NSUInteger)cost block:(PINCacheBlock)block
+- (void)trimToCostAsync:(NSUInteger)cost completion:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -366,7 +366,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)trimToCostByDateAsync:(NSUInteger)cost block:(PINCacheBlock)block
+- (void)trimToCostByDateAsync:(NSUInteger)cost completion:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -775,42 +775,42 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 
 - (void)containsObjectForKey:(NSString *)key block:(PINMemoryCacheContainmentBlock)block
 {
-    [self containsObjectForKeyAsync:key block:block];
+    [self containsObjectForKeyAsync:key completion:block];
 }
 
 - (void)objectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block
 {
-    [self objectForKeyAsync:key block:block];
+    [self objectForKeyAsync:key completion:block];
 }
 
 - (void)setObject:(id)object forKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block
 {
-    [self setObjectAsync:object forKey:key block:block];
+    [self setObjectAsync:object forKey:key completion:block];
 }
 
 - (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINMemoryCacheObjectBlock)block
 {
-    [self setObjectAsync:object forKey:key withCost:cost block:block];
+    [self setObjectAsync:object forKey:key withCost:cost completion:block];
 }
 
 - (void)removeObjectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block
 {
-    [self removeObjectForKeyAsync:key block:block];
+    [self removeObjectForKeyAsync:key completion:block];
 }
 
 - (void)trimToDate:(NSDate *)date block:(nullable PINMemoryCacheBlock)block
 {
-    [self trimToDateAsync:date block:block];
+    [self trimToDateAsync:date completion:block];
 }
 
 - (void)trimToCost:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block
 {
-    [self trimToCostAsync:cost block:block];
+    [self trimToCostAsync:cost completion:block];
 }
 
 - (void)trimToCostByDate:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block
 {
-    [self trimToCostByDateAsync:cost block:block];
+    [self trimToCostByDateAsync:cost completion:block];
 }
 
 - (void)removeAllObjects:(nullable PINMemoryCacheBlock)block

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -768,3 +768,60 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 }
 
 @end
+
+
+#pragma mark - Deprecated
+
+@implementation PINMemoryCache (Deprecated)
+
+- (void)containsObjectForKey:(NSString *)key block:(PINMemoryCacheContainmentBlock)block
+{
+    [self asyncContainsObjectForKey:key block:block];
+}
+
+- (void)objectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block
+{
+    [self asyncObjectForKey:key block:block];
+}
+
+- (void)setObject:(id)object forKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block
+{
+    [self asyncSetObject:object forKey:key block:block];
+}
+
+- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINMemoryCacheObjectBlock)block
+{
+    [self asyncSetObject:object forKey:key withCost:cost block:block];
+}
+
+- (void)removeObjectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block
+{
+    [self asyncRemoveObjectForKey:key block:block];
+}
+
+- (void)trimToDate:(NSDate *)date block:(nullable PINMemoryCacheBlock)block
+{
+    [self asyncTrimToDate:date block:block];
+}
+
+- (void)trimToCost:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block
+{
+    [self asyncTrimToCost:cost block:block];
+}
+
+- (void)trimToCostByDate:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block
+{
+    [self asyncTrimToCostByDate:cost block:block];
+}
+
+- (void)removeAllObjects:(nullable PINMemoryCacheBlock)block
+{
+    [self asyncRemoveAllObjects:block];
+}
+
+- (void)enumerateObjectsWithBlock:(PINMemoryCacheObjectBlock)block completionBlock:(nullable PINMemoryCacheBlock)completionBlock
+{
+    [self asyncEnumerateObjectsWithBlock:block completionBlock:completionBlock];
+}
+
+@end

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -305,8 +305,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
         PINMemoryCache *strongSelf = weakSelf;
         id object = [strongSelf objectForKey:key];
         
-        if (block)
-            block(strongSelf, key, object);
+        block(strongSelf, key, object);
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
@@ -419,7 +418,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     return containsObject;
 }
 
-- (__nullable id)objectForKey:(NSString *)key
+- (nullable id)objectForKey:(NSString *)key
 {
     if (!key)
         return nil;

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -121,7 +121,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 
 - (void)didReceiveMemoryWarningNotification:(NSNotification *)notification {
     if (self.removeAllObjectsOnMemoryWarning)
-        [self asyncRemoveAllObjects:nil];
+        [self removeAllObjectsAsync:nil];
 
     __weak PINMemoryCache *weakSelf = self;
 
@@ -143,7 +143,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 - (void)didReceiveEnterBackgroundNotification:(NSNotification *)notification
 {
     if (self.removeAllObjectsOnEnteringBackground)
-        [self asyncRemoveAllObjects:nil];
+        [self removeAllObjectsAsync:nil];
 
     __weak PINMemoryCache *weakSelf = self;
 
@@ -282,7 +282,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 
 #pragma mark - Public Asynchronous Methods -
 
-- (void)asyncContainsObjectForKey:(NSString *)key block:(PINCacheObjectContainmentBlock)block
+- (void)containsObjectForKeyAsync:(NSString *)key block:(PINCacheObjectContainmentBlock)block
 {
     if (!key || !block)
         return;
@@ -297,7 +297,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)asyncObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)objectForKeyAsync:(NSString *)key block:(PINCacheObjectBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -309,12 +309,12 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)asyncSetObject:(id)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)setObjectAsync:(id)object forKey:(NSString *)key block:(PINCacheObjectBlock)block
 {
-    [self asyncSetObject:object forKey:key withCost:0 block:block];
+    [self setObjectAsync:object forKey:key withCost:0 block:block];
 }
 
-- (void)asyncSetObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
+- (void)setObjectAsync:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(PINCacheObjectBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -327,7 +327,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)asyncRemoveObjectForKey:(NSString *)key block:(PINCacheObjectBlock)block
+- (void)removeObjectForKeyAsync:(NSString *)key block:(PINCacheObjectBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -340,7 +340,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)asyncTrimToDate:(NSDate *)trimDate block:(PINCacheBlock)block
+- (void)trimToDateAsync:(NSDate *)trimDate block:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -353,7 +353,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)asyncTrimToCost:(NSUInteger)cost block:(PINCacheBlock)block
+- (void)trimToCostAsync:(NSUInteger)cost block:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -366,7 +366,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)asyncTrimToCostByDate:(NSUInteger)cost block:(PINCacheBlock)block
+- (void)trimToCostByDateAsync:(NSUInteger)cost block:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -379,7 +379,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)asyncRemoveAllObjects:(PINCacheBlock)block
+- (void)removeAllObjectsAsync:(PINCacheBlock)block
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -392,7 +392,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     } withPriority:PINOperationQueuePriorityHigh];
 }
 
-- (void)asyncEnumerateObjectsWithBlock:(PINCacheObjectBlock)block completionBlock:(PINCacheBlock)completionBlock
+- (void)enumerateObjectsWithBlockAsync:(PINCacheObjectBlock)block completionBlock:(PINCacheBlock)completionBlock
 {
     __weak PINMemoryCache *weakSelf = self;
     
@@ -775,52 +775,52 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 
 - (void)containsObjectForKey:(NSString *)key block:(PINMemoryCacheContainmentBlock)block
 {
-    [self asyncContainsObjectForKey:key block:block];
+    [self containsObjectForKeyAsync:key block:block];
 }
 
 - (void)objectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block
 {
-    [self asyncObjectForKey:key block:block];
+    [self objectForKeyAsync:key block:block];
 }
 
 - (void)setObject:(id)object forKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block
 {
-    [self asyncSetObject:object forKey:key block:block];
+    [self setObjectAsync:object forKey:key block:block];
 }
 
 - (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINMemoryCacheObjectBlock)block
 {
-    [self asyncSetObject:object forKey:key withCost:cost block:block];
+    [self setObjectAsync:object forKey:key withCost:cost block:block];
 }
 
 - (void)removeObjectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block
 {
-    [self asyncRemoveObjectForKey:key block:block];
+    [self removeObjectForKeyAsync:key block:block];
 }
 
 - (void)trimToDate:(NSDate *)date block:(nullable PINMemoryCacheBlock)block
 {
-    [self asyncTrimToDate:date block:block];
+    [self trimToDateAsync:date block:block];
 }
 
 - (void)trimToCost:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block
 {
-    [self asyncTrimToCost:cost block:block];
+    [self trimToCostAsync:cost block:block];
 }
 
 - (void)trimToCostByDate:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block
 {
-    [self asyncTrimToCostByDate:cost block:block];
+    [self trimToCostByDateAsync:cost block:block];
 }
 
 - (void)removeAllObjects:(nullable PINMemoryCacheBlock)block
 {
-    [self asyncRemoveAllObjects:block];
+    [self removeAllObjectsAsync:block];
 }
 
 - (void)enumerateObjectsWithBlock:(PINMemoryCacheObjectBlock)block completionBlock:(nullable PINMemoryCacheBlock)completionBlock
 {
-    [self asyncEnumerateObjectsWithBlock:block completionBlock:completionBlock];
+    [self enumerateObjectsWithBlockAsync:block completionBlock:completionBlock];
 }
 
 @end

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -109,7 +109,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Wait for URL to be created
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
-    [self.cache asyncObjectForKey:@"" block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+    [self.cache objectForKeyAsync:@"" block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
       dispatch_group_leave(group);
     }];
 
@@ -127,7 +127,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block PINImage *image = nil;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     
-    [self.cache asyncSetObject:[self image] forKey:key block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache setObjectAsync:[self image] forKey:key block:^(PINCache *cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -145,7 +145,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     PINImage *srcImage = [self image];
     NSUInteger cost = (NSUInteger)(srcImage.size.width * srcImage.size.height);
     
-    [self.cache asyncSetObject:srcImage forKey:key withCost:cost block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache setObjectAsync:srcImage forKey:key withCost:cost block:^(PINCache *cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -167,7 +167,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     [self.cache setObject:value1 forKey:key];
     [self.cache setObject:value2 forKey:key];
     
-    [self.cache asyncObjectForKey:key block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache objectForKeyAsync:key block:^(PINCache *cache, NSString *key, id object) {
         cachedValue = (NSString *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -190,7 +190,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Asynchronously
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     __block BOOL cacheContainsObject = NO;
-    [self.cache asyncContainsObjectForKey:key block:^(BOOL containsObject) {
+    [self.cache containsObjectForKeyAsync:key block:^(BOOL containsObject) {
         cacheContainsObject = containsObject;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -212,7 +212,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Asynchronously
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     __block BOOL cacheContainsObject = NO;
-    [self.cache asyncContainsObjectForKey:key block:^(BOOL containsObject) {
+    [self.cache containsObjectForKeyAsync:key block:^(BOOL containsObject) {
         cacheContainsObject = containsObject;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -230,7 +230,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     
     self.cache[key] = [self image];
     
-    [self.cache asyncObjectForKey:key block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache objectForKeyAsync:key block:^(PINCache *cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -249,7 +249,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     self.cache[key] = [self image];
 
-    [self.cache asyncObjectForKey:invalidKey block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache objectForKeyAsync:invalidKey block:^(PINCache *cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -266,7 +266,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     
     self.cache[key] = [self image];
     
-    [self.cache asyncRemoveObjectForKey:key block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache removeObjectForKeyAsync:key block:^(PINCache *cache, NSString *key, id object) {
         dispatch_semaphore_signal(semaphore);
     }];
     
@@ -286,7 +286,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     self.cache[key1] = key1;
     self.cache[key2] = key2;
     
-    [self.cache asyncRemoveAllObjects:^(PINCache *cache) {
+    [self.cache removeAllObjectsAsync:^(PINCache *cache) {
         dispatch_semaphore_signal(semaphore);
     }];
     
@@ -385,9 +385,9 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
         dispatch_group_enter(group);
-        [self.cache asyncSetObject:obj forKey:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+        [self.cache setObjectAsync:obj forKey:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
             dispatch_async(queue, ^{
-                [self.cache asyncObjectForKey:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+                [self.cache objectForKeyAsync:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
                     NSString *obj = [[NSString alloc] initWithFormat:@"obj %lu", (unsigned long)i];
                     XCTAssertTrue([object isEqualToString:obj] == YES, @"object returned was not object set");
                     @synchronized (self) {
@@ -463,7 +463,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
 - (void)testMemoryWarningProperty
 {
-    [self.cache.memoryCache asyncSetObject:@"object" forKey:@"object" block:nil];
+    [self.cache.memoryCache setObjectAsync:@"object" forKey:@"object" block:nil];
 
     self.cache.memoryCache.removeAllObjectsOnMemoryWarning = NO;
 
@@ -501,7 +501,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block NSUInteger enumCount = 0;
 
     self.cache.memoryCache.didReceiveMemoryWarningBlock = ^(PINMemoryCache *cache) {
-        [cache asyncEnumerateObjectsWithBlock:^(PINMemoryCache *cache, NSString *key, id object) {
+        [cache enumerateObjectsWithBlockAsync:^(PINMemoryCache *cache, NSString *key, id object) {
             @synchronized (self) {
                 enumCount++;
             }
@@ -530,7 +530,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
         NSString *key = [[NSString alloc] initWithFormat:@"key %zd", index];
         NSString *obj = [[NSString alloc] initWithFormat:@"obj %zd", index];
         dispatch_group_enter(group);
-        [self.cache.diskCache asyncSetObject:obj forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+        [self.cache.diskCache setObjectAsync:obj forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
             dispatch_group_leave(group);
         }];
     });
@@ -541,7 +541,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     __block NSUInteger enumCount = 0;
 
-    [self.cache.diskCache asyncEnumerateObjectsWithBlock:^(NSString *key, NSURL *fileURL) {
+    [self.cache.diskCache enumerateObjectsWithBlockAsync:^(NSString *key, NSURL *fileURL) {
         @synchronized (self) {
             enumCount++;
         }
@@ -598,13 +598,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block id diskObj = nil;
     
     dispatch_group_enter(group);
-    [self.cache.memoryCache asyncObjectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key block:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
     
     dispatch_group_enter(group);
-    [self.cache.diskCache asyncObjectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -620,13 +620,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     sleep(2);
     
     dispatch_group_enter(group);
-    [self.cache.memoryCache asyncObjectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key block:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
     
     dispatch_group_enter(group);
-    [self.cache.diskCache asyncObjectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -646,8 +646,8 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
   __block NSURL *diskFileURL = nil;
   dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-  [self.cache.diskCache asyncSetObject:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
-    [cache asyncFileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
+  [self.cache.diskCache setObjectAsync:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [cache fileURLForKeyAsync:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
         diskFileURL = fileURL;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -687,13 +687,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block id diskObj = nil;
 
     dispatch_group_enter(group);
-    [self.cache.memoryCache asyncObjectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key block:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
 
     dispatch_group_enter(group);
-    [self.cache.diskCache asyncObjectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -711,13 +711,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     diskObj = nil;
 
     dispatch_group_enter(group);
-    [self.cache.memoryCache asyncObjectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key block:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
 
     dispatch_group_enter(group);
-    [self.cache.diskCache asyncObjectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -749,7 +749,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Wait for ttlCache to be set
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
-    [self.cache.diskCache asyncObjectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+    [self.cache.diskCache objectForKeyAsync:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
         dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
@@ -775,7 +775,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     // Wait for ttlCache to be set
     dispatch_group_enter(group);
-    [self.cache.diskCache asyncObjectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+    [self.cache.diskCache objectForKeyAsync:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
         dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
@@ -804,8 +804,8 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
     __block NSURL *objectURL = nil;
-    [self.cache.diskCache asyncSetObject:[self image] forKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
-        [cache asyncFileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
+    [self.cache.diskCache setObjectAsync:[self image] forKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+        [cache fileURLForKeyAsync:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
             objectURL = fileURL;
             dispatch_group_leave(group);
         }];
@@ -887,8 +887,8 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block NSURL *diskFileURL = nil;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     
-    [cache.diskCache asyncSetObject:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
-        [cache asyncFileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
+    [cache.diskCache setObjectAsync:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+        [cache fileURLForKeyAsync:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
             diskFileURL = fileURL;
             dispatch_semaphore_signal(semaphore);
         }];
@@ -955,7 +955,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     }
     
     dispatch_group_enter(group);
-    [self.cache.diskCache asyncRemoveAllObjects:^(PINDiskCache * _Nonnull cache) {
+    [self.cache.diskCache removeAllObjectsAsync:^(PINDiskCache * _Nonnull cache) {
         // Temporary directory should be bigger now since the trash directory is still inside it
         NSError *error = nil;
         unsigned long long tempDirSize = [[fileManager attributesOfItemAtPath:tempDirPath error:&error] fileSize];

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -646,8 +646,8 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
   __block NSURL *diskFileURL = nil;
   dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-  [self.cache.diskCache setObject:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
-    [cache fileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
+  [self.cache.diskCache asyncSetObject:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [cache asyncFileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
         diskFileURL = fileURL;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -764,7 +764,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", (unsigned long)expectedObjCount);
 
     objCount = 0;
-    [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache *cache, NSString *key, id __nullable object) {
+    [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache *cache, NSString *key, id _Nullable object) {
       objCount++;
     }];
 

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -109,7 +109,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Wait for URL to be created
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
-    [self.cache objectForKeyAsync:@"" block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+    [self.cache objectForKeyAsync:@"" completion:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
       dispatch_group_leave(group);
     }];
 
@@ -127,7 +127,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block PINImage *image = nil;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     
-    [self.cache setObjectAsync:[self image] forKey:key block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache setObjectAsync:[self image] forKey:key completion:^(PINCache *cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -145,7 +145,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     PINImage *srcImage = [self image];
     NSUInteger cost = (NSUInteger)(srcImage.size.width * srcImage.size.height);
     
-    [self.cache setObjectAsync:srcImage forKey:key withCost:cost block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache setObjectAsync:srcImage forKey:key withCost:cost completion:^(PINCache *cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -167,7 +167,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     [self.cache setObject:value1 forKey:key];
     [self.cache setObject:value2 forKey:key];
     
-    [self.cache objectForKeyAsync:key block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache objectForKeyAsync:key completion:^(PINCache *cache, NSString *key, id object) {
         cachedValue = (NSString *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -190,7 +190,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Asynchronously
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     __block BOOL cacheContainsObject = NO;
-    [self.cache containsObjectForKeyAsync:key block:^(BOOL containsObject) {
+    [self.cache containsObjectForKeyAsync:key completion:^(BOOL containsObject) {
         cacheContainsObject = containsObject;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -212,7 +212,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Asynchronously
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     __block BOOL cacheContainsObject = NO;
-    [self.cache containsObjectForKeyAsync:key block:^(BOOL containsObject) {
+    [self.cache containsObjectForKeyAsync:key completion:^(BOOL containsObject) {
         cacheContainsObject = containsObject;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -230,7 +230,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     
     self.cache[key] = [self image];
     
-    [self.cache objectForKeyAsync:key block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache objectForKeyAsync:key completion:^(PINCache *cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -249,7 +249,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     self.cache[key] = [self image];
 
-    [self.cache objectForKeyAsync:invalidKey block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache objectForKeyAsync:invalidKey completion:^(PINCache *cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -266,7 +266,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     
     self.cache[key] = [self image];
     
-    [self.cache removeObjectForKeyAsync:key block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache removeObjectForKeyAsync:key completion:^(PINCache *cache, NSString *key, id object) {
         dispatch_semaphore_signal(semaphore);
     }];
     
@@ -385,9 +385,9 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
         dispatch_group_enter(group);
-        [self.cache setObjectAsync:obj forKey:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+        [self.cache setObjectAsync:obj forKey:key completion:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
             dispatch_async(queue, ^{
-                [self.cache objectForKeyAsync:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+                [self.cache objectForKeyAsync:key completion:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
                     NSString *obj = [[NSString alloc] initWithFormat:@"obj %lu", (unsigned long)i];
                     XCTAssertTrue([object isEqualToString:obj] == YES, @"object returned was not object set");
                     @synchronized (self) {
@@ -463,7 +463,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
 - (void)testMemoryWarningProperty
 {
-    [self.cache.memoryCache setObjectAsync:@"object" forKey:@"object" block:nil];
+    [self.cache.memoryCache setObjectAsync:@"object" forKey:@"object" completion:nil];
 
     self.cache.memoryCache.removeAllObjectsOnMemoryWarning = NO;
 
@@ -530,7 +530,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
         NSString *key = [[NSString alloc] initWithFormat:@"key %zd", index];
         NSString *obj = [[NSString alloc] initWithFormat:@"obj %zd", index];
         dispatch_group_enter(group);
-        [self.cache.diskCache setObjectAsync:obj forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+        [self.cache.diskCache setObjectAsync:obj forKey:key completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
             dispatch_group_leave(group);
         }];
     });
@@ -598,13 +598,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block id diskObj = nil;
     
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKeyAsync:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key completion:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
     
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKeyAsync:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -620,13 +620,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     sleep(2);
     
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKeyAsync:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key completion:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
     
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKeyAsync:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -646,8 +646,8 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
   __block NSURL *diskFileURL = nil;
   dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-  [self.cache.diskCache setObjectAsync:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
-    [cache fileURLForKeyAsync:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
+  [self.cache.diskCache setObjectAsync:[self image] forKey:key completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [cache fileURLForKeyAsync:key completion:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
         diskFileURL = fileURL;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -687,13 +687,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block id diskObj = nil;
 
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKeyAsync:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key completion:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
 
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKeyAsync:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -711,13 +711,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     diskObj = nil;
 
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKeyAsync:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key completion:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
 
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKeyAsync:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -749,7 +749,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Wait for ttlCache to be set
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKeyAsync:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+    [self.cache.diskCache objectForKeyAsync:key completion:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
         dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
@@ -775,7 +775,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     // Wait for ttlCache to be set
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKeyAsync:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+    [self.cache.diskCache objectForKeyAsync:key completion:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
         dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
@@ -804,8 +804,8 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
     __block NSURL *objectURL = nil;
-    [self.cache.diskCache setObjectAsync:[self image] forKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
-        [cache fileURLForKeyAsync:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
+    [self.cache.diskCache setObjectAsync:[self image] forKey:key completion:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+        [cache fileURLForKeyAsync:key completion:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
             objectURL = fileURL;
             dispatch_group_leave(group);
         }];
@@ -887,8 +887,8 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block NSURL *diskFileURL = nil;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     
-    [cache.diskCache setObjectAsync:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
-        [cache fileURLForKeyAsync:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
+    [cache.diskCache setObjectAsync:[self image] forKey:key completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+        [cache fileURLForKeyAsync:key completion:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
             diskFileURL = fileURL;
             dispatch_semaphore_signal(semaphore);
         }];

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -109,7 +109,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Wait for URL to be created
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
-    [self.cache objectForKey:@"" block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+    [self.cache asyncObjectForKey:@"" block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
       dispatch_group_leave(group);
     }];
 
@@ -127,7 +127,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block PINImage *image = nil;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     
-    [self.cache setObject:[self image] forKey:key block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache asyncSetObject:[self image] forKey:key block:^(PINCache *cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -145,7 +145,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     PINImage *srcImage = [self image];
     NSUInteger cost = (NSUInteger)(srcImage.size.width * srcImage.size.height);
     
-    [self.cache setObject:srcImage forKey:key withCost:cost block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache asyncSetObject:srcImage forKey:key withCost:cost block:^(PINCache *cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -167,7 +167,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     [self.cache setObject:value1 forKey:key];
     [self.cache setObject:value2 forKey:key];
     
-    [self.cache objectForKey:key block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache asyncObjectForKey:key block:^(PINCache *cache, NSString *key, id object) {
         cachedValue = (NSString *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -190,7 +190,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Asynchronously
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     __block BOOL cacheContainsObject = NO;
-    [self.cache containsObjectForKey:key block:^(BOOL containsObject) {
+    [self.cache asyncContainsObjectForKey:key block:^(BOOL containsObject) {
         cacheContainsObject = containsObject;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -212,7 +212,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Asynchronously
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     __block BOOL cacheContainsObject = NO;
-    [self.cache containsObjectForKey:key block:^(BOOL containsObject) {
+    [self.cache asyncContainsObjectForKey:key block:^(BOOL containsObject) {
         cacheContainsObject = containsObject;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -230,7 +230,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     
     self.cache[key] = [self image];
     
-    [self.cache objectForKey:key block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache asyncObjectForKey:key block:^(PINCache *cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -249,7 +249,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     self.cache[key] = [self image];
 
-    [self.cache objectForKey:invalidKey block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache asyncObjectForKey:invalidKey block:^(PINCache *cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -266,7 +266,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     
     self.cache[key] = [self image];
     
-    [self.cache removeObjectForKey:key block:^(PINCache *cache, NSString *key, id object) {
+    [self.cache asyncRemoveObjectForKey:key block:^(PINCache *cache, NSString *key, id object) {
         dispatch_semaphore_signal(semaphore);
     }];
     
@@ -286,7 +286,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     self.cache[key1] = key1;
     self.cache[key2] = key2;
     
-    [self.cache removeAllObjects:^(PINCache *cache) {
+    [self.cache asyncRemoveAllObjects:^(PINCache *cache) {
         dispatch_semaphore_signal(semaphore);
     }];
     
@@ -385,9 +385,9 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
         dispatch_group_enter(group);
-        [self.cache setObject:obj forKey:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+        [self.cache asyncSetObject:obj forKey:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
             dispatch_async(queue, ^{
-                [self.cache objectForKey:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+                [self.cache asyncObjectForKey:key block:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
                     NSString *obj = [[NSString alloc] initWithFormat:@"obj %lu", (unsigned long)i];
                     XCTAssertTrue([object isEqualToString:obj] == YES, @"object returned was not object set");
                     @synchronized (self) {
@@ -463,7 +463,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
 - (void)testMemoryWarningProperty
 {
-    [self.cache.memoryCache setObject:@"object" forKey:@"object" block:nil];
+    [self.cache.memoryCache asyncSetObject:@"object" forKey:@"object" block:nil];
 
     self.cache.memoryCache.removeAllObjectsOnMemoryWarning = NO;
 
@@ -501,7 +501,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block NSUInteger enumCount = 0;
 
     self.cache.memoryCache.didReceiveMemoryWarningBlock = ^(PINMemoryCache *cache) {
-        [cache enumerateObjectsWithBlock:^(PINMemoryCache *cache, NSString *key, id object) {
+        [cache asyncEnumerateObjectsWithBlock:^(PINMemoryCache *cache, NSString *key, id object) {
             @synchronized (self) {
                 enumCount++;
             }
@@ -530,7 +530,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
         NSString *key = [[NSString alloc] initWithFormat:@"key %zd", index];
         NSString *obj = [[NSString alloc] initWithFormat:@"obj %zd", index];
         dispatch_group_enter(group);
-        [self.cache.diskCache setObject:obj forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+        [self.cache.diskCache asyncSetObject:obj forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
             dispatch_group_leave(group);
         }];
     });
@@ -541,7 +541,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     __block NSUInteger enumCount = 0;
 
-    [self.cache.diskCache enumerateObjectsWithBlock:^(NSString *key, NSURL *fileURL) {
+    [self.cache.diskCache asyncEnumerateObjectsWithBlock:^(NSString *key, NSURL *fileURL) {
         @synchronized (self) {
             enumCount++;
         }
@@ -598,13 +598,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block id diskObj = nil;
     
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache asyncObjectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
     
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache asyncObjectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -620,13 +620,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     sleep(2);
     
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache asyncObjectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
     
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache asyncObjectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -687,13 +687,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block id diskObj = nil;
 
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache asyncObjectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
 
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache asyncObjectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -711,13 +711,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     diskObj = nil;
 
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache asyncObjectForKey:key block:^(PINMemoryCache *cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
 
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache asyncObjectForKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -749,7 +749,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Wait for ttlCache to be set
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+    [self.cache.diskCache asyncObjectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
         dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
@@ -775,7 +775,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     // Wait for ttlCache to be set
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+    [self.cache.diskCache asyncObjectForKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
         dispatch_group_leave(group);
     }];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
@@ -804,8 +804,8 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
     __block NSURL *objectURL = nil;
-    [self.cache.diskCache setObject:[self image] forKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
-        [cache fileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
+    [self.cache.diskCache asyncSetObject:[self image] forKey:key block:^(PINDiskCache * _Nonnull cache, NSString * _Nonnull key, id<NSCoding>  _Nullable object) {
+        [cache asyncFileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
             objectURL = fileURL;
             dispatch_group_leave(group);
         }];
@@ -887,8 +887,8 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block NSURL *diskFileURL = nil;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     
-    [cache.diskCache setObject:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
-        [cache fileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
+    [cache.diskCache asyncSetObject:[self image] forKey:key block:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+        [cache asyncFileURLForKey:key block:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
             diskFileURL = fileURL;
             dispatch_semaphore_signal(semaphore);
         }];
@@ -955,7 +955,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     }
     
     dispatch_group_enter(group);
-    [self.cache.diskCache removeAllObjects:^(PINDiskCache * _Nonnull cache) {
+    [self.cache.diskCache asyncRemoveAllObjects:^(PINDiskCache * _Nonnull cache) {
         // Temporary directory should be bigger now since the trash directory is still inside it
         NSError *error = nil;
         unsigned long long tempDirSize = [[fileManager attributesOfItemAtPath:tempDirPath error:&error] fileSize];


### PR DESCRIPTION
The PINCaching protocol contains methods that all three cache classes are implementing and all declared in the header. With PINCaching we can have a consistent API across all components and could mostly remove some duplicated API definitions in the header files too.

Furthermore with this PR we will rename the asynchronous API's to a more expressive name.

### TODOs
- [x] Rename async methods
- [x] Deprecate old async methods
- [x] Look over documentation and small cleanup due to async method deprecations
- [x] Rename async API to `setObjectAsync:forKey:completion:`