### PR TITLE
This is a temporary fix. Currently Carthage is required to build PINC…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ test:
 carthage:
 	carthage update
 
-all: lint test carthage
+all: carthage lint test


### PR DESCRIPTION
…ache, we probably want to decide on one build system.

Also renames makefile -> Makefile