### PR TITLE
Redefined import error fix

### DIFF
--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -485,11 +485,6 @@ PIN_SUBCLASSING_RESTRICTED
  */
 typedef void (^PINDiskCacheBlock)(PINDiskCache *cache);
 
-/**
- A callback block which provides the cache, key and object as arguments
- */
-typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding> _Nullable object);
-
 @interface PINDiskCache (Deprecated)
 - (void)lockFileAccessWhileExecutingBlock:(nullable PINCacheBlock)block __attribute__((deprecated));
 - (void)containsObjectForKey:(NSString *)key block:(PINDiskCacheContainsBlock)block __attribute__((deprecated));


### PR DESCRIPTION
On newer versions of clang, (specifically tested with 3.9), the
inclusion of the typedef in the deprecated section causes a build
failure (which I can't seem to suppress):

```
Redefinition of typedef 'PINDiskCacheObjectBlock' is a C11 feature
```