### PR TITLE
Removes period from encoded characters

### DIFF
--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -231,7 +231,7 @@ static NSURL *_sharedTrashURL;
     }
     
     if ([string respondsToSelector:@selector(stringByAddingPercentEncodingWithAllowedCharacters:)]) {
-        NSString *encodedString = [string stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@".:/%"] invertedSet]];
+        NSString *encodedString = [string stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@":/%"] invertedSet]];
         if (self.fileExtension.length > 0) {
             return [encodedString stringByAppendingPathExtension:self.fileExtension];
         }
@@ -240,7 +240,7 @@ static NSURL *_sharedTrashURL;
         }
     }
     else {
-        CFStringRef static const charsToEscape = CFSTR(".:/%");
+        CFStringRef static const charsToEscape = CFSTR(":/%");
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         CFStringRef escapedString = CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -93,7 +93,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 - (void)testDiskCacheStringEncoding
 {
     NSString *string = [self.cache.diskCache encodedString:@"http://www.test.de-<CoolStuff>?%"];
-    XCTAssertTrue([string isEqualToString:@"http%3A%2F%2Fwww%2Etest%2Ede-<CoolStuff>?%25"]);
+    XCTAssertTrue([string isEqualToString:@"http%3A%2F%2Fwww.test.de-<CoolStuff>?%25"]);
 }
 
 - (void)testCoreProperties


### PR DESCRIPTION
Encoding periods prevents mp4 files stored in `PINCache` from playing correctly in `AVFoundation`’s `AVPlayerItem` objects. To my knowledge it should be fine to leave periods unencoded.