### PR TITLE
added a way to set custom key encoder/decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this with your name.
+- [new] Added an ability to set custom encoder/decoder for file names: [#192](https://github.com/pinterest/PINCache/pull/192)
 
 ## 2.2.1 -- 2016 Mar 5
 - [new] Removed need for extension macro: [#72](https://github.com/pinterest/PINCache/pull/72)

--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -111,7 +111,36 @@ PIN_SUBCLASSING_RESTRICTED
  @param fileExtension The file extension for files on disk.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer fileExtension:(nullable NSString *)fileExtension NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithName:(NSString *)name
+                    rootPath:(NSString *)rootPath
+                  serializer:(nullable PINDiskCacheSerializerBlock)serializer
+                deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
+               fileExtension:(NSString *)fileExtension;
+
+
+/**
+ Multiple instances with the same name are allowed and can safely access
+ the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
+ Initializer allows you to override default NSKeyedArchiver/NSKeyedUnarchiver serialization for <diskCache>.
+ You must provide both serializer and deserializer, or opt-out to default implementation providing nil values.
+ 
+ @see name
+ @param name The name of the cache.
+ @param rootPath The path of the cache on disk.
+ @param serializer   A block used to serialize object before writing to disk. If nil provided, default NSKeyedArchiver serialized will be used.
+ @param deserializer A block used to deserialize object read from disk. If nil provided, default NSKeyedUnarchiver serialized will be used.
+ @param keyEncoder A block used to encode key(filename). If nil provided, default url encoder will be used
+ @param keyDecoder A block used to decode key(filename). If nil provided, default url decoder will be used
+ @param fileExtension The file extension for files on disk.
+ @result A new cache with the specified name.
+ */
+- (instancetype)initWithName:(nonnull NSString *)name
+                    rootPath:(nonnull NSString *)rootPath
+                  serializer:(nullable PINDiskCacheSerializerBlock)serializer
+                deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
+                  keyEncoder:(nullable PINDiskCacheKeyEncoderBlock)keyEncoder
+                  keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyDecoder
+               fileExtension:(nullable NSString *)fileExtension NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -115,7 +115,7 @@ PIN_SUBCLASSING_RESTRICTED
                     rootPath:(NSString *)rootPath
                   serializer:(nullable PINDiskCacheSerializerBlock)serializer
                 deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
-               fileExtension:(NSString *)fileExtension;
+               fileExtension:(nullable NSString *)fileExtension;
 
 
 /**

--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -65,8 +65,8 @@ PIN_SUBCLASSING_RESTRICTED
 - (instancetype)init NS_UNAVAILABLE;
 
 /**
- Multiple instances with the same name are allowed and can safely access
- the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
+ Multiple instances with the same name are *not* allowed and can *not* safely
+ access the same data on disk. Also used to create the <diskCache>.
  
  @see name
  @param name The name of the cache.
@@ -75,8 +75,8 @@ PIN_SUBCLASSING_RESTRICTED
 - (instancetype)initWithName:(nonnull NSString *)name;
 
 /**
- Multiple instances with the same name are allowed and can safely access
- the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
+ Multiple instances with the same name are *not* allowed and can *not* safely
+ access the same data on disk.. Also used to create the <diskCache>.
  
  @see name
  @param name The name of the cache.
@@ -86,8 +86,8 @@ PIN_SUBCLASSING_RESTRICTED
 - (instancetype)initWithName:(nonnull NSString *)name fileExtension:(nullable NSString *)fileExtension;
 
 /**
- Multiple instances with the same name are allowed and can safely access
- the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
+ Multiple instances with the same name are *not* allowed and can *not* safely
+ access the same data on disk. Also used to create the <diskCache>.
  
  @see name
  @param name The name of the cache.
@@ -98,8 +98,8 @@ PIN_SUBCLASSING_RESTRICTED
 - (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath fileExtension:(nullable NSString *)fileExtension;
 
 /**
- Multiple instances with the same name are allowed and can safely access
- the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
+ Multiple instances with the same name are *not* allowed and can *not* safely
+ access the same data on disk.. Also used to create the <diskCache>.
  Initializer allows you to override default NSKeyedArchiver/NSKeyedUnarchiver serialization for <diskCache>.
  You must provide both serializer and deserializer, or opt-out to default implementation providing nil values.
  
@@ -119,8 +119,8 @@ PIN_SUBCLASSING_RESTRICTED
 
 
 /**
- Multiple instances with the same name are allowed and can safely access
- the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
+ Multiple instances with the same name are *not* allowed and can *not* safely
+ access the same data on disk. Also used to create the <diskCache>.
  Initializer allows you to override default NSKeyedArchiver/NSKeyedUnarchiver serialization for <diskCache>.
  You must provide both serializer and deserializer, or opt-out to default implementation providing nil values.
  

--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -76,26 +76,14 @@ PIN_SUBCLASSING_RESTRICTED
 
 /**
  Multiple instances with the same name are *not* allowed and can *not* safely
- access the same data on disk.. Also used to create the <diskCache>.
- 
- @see name
- @param name The name of the cache.
- @param fileExtension The file extension for files on disk.
- @result A new cache with the specified name.
- */
-- (instancetype)initWithName:(nonnull NSString *)name fileExtension:(nullable NSString *)fileExtension;
-
-/**
- Multiple instances with the same name are *not* allowed and can *not* safely
  access the same data on disk. Also used to create the <diskCache>.
  
  @see name
  @param name The name of the cache.
  @param rootPath The path of the cache on disk.
- @param fileExtension The file extension for files on disk.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath fileExtension:(nullable NSString *)fileExtension;
+- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath;
 
 /**
  Multiple instances with the same name are *not* allowed and can *not* safely
@@ -108,14 +96,12 @@ PIN_SUBCLASSING_RESTRICTED
  @param rootPath The path of the cache on disk.
  @param serializer   A block used to serialize object before writing to disk. If nil provided, default NSKeyedArchiver serialized will be used.
  @param deserializer A block used to deserialize object read from disk. If nil provided, default NSKeyedUnarchiver serialized will be used.
- @param fileExtension The file extension for files on disk.
  @result A new cache with the specified name.
  */
 - (instancetype)initWithName:(NSString *)name
                     rootPath:(NSString *)rootPath
                   serializer:(nullable PINDiskCacheSerializerBlock)serializer
-                deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
-               fileExtension:(nullable NSString *)fileExtension;
+                deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer;
 
 
 /**
@@ -131,7 +117,6 @@ PIN_SUBCLASSING_RESTRICTED
  @param deserializer A block used to deserialize object read from disk. If nil provided, default NSKeyedUnarchiver serialized will be used.
  @param keyEncoder A block used to encode key(filename). If nil provided, default url encoder will be used
  @param keyDecoder A block used to decode key(filename). If nil provided, default url decoder will be used
- @param fileExtension The file extension for files on disk.
  @result A new cache with the specified name.
  */
 - (instancetype)initWithName:(nonnull NSString *)name
@@ -139,8 +124,7 @@ PIN_SUBCLASSING_RESTRICTED
                   serializer:(nullable PINDiskCacheSerializerBlock)serializer
                 deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
                   keyEncoder:(nullable PINDiskCacheKeyEncoderBlock)keyEncoder
-                  keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyDecoder
-               fileExtension:(nullable NSString *)fileExtension NS_DESIGNATED_INITIALIZER;
+                  keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyDecoder NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -26,21 +26,16 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 
 - (instancetype)initWithName:(NSString *)name
 {
-    return [self initWithName:name fileExtension:nil];
+    return [self initWithName:name rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject]];
 }
 
-- (instancetype)initWithName:(NSString *)name fileExtension:(NSString *)fileExtension
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath
 {
-    return [self initWithName:name rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject] fileExtension:fileExtension];
+    return [self initWithName:name rootPath:rootPath serializer:nil deserializer:nil];
 }
 
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath fileExtension:(NSString *)fileExtension
-{
-    return [self initWithName:name rootPath:rootPath serializer:nil deserializer:nil fileExtension:fileExtension];
-}
-
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(PINDiskCacheSerializerBlock)serializer deserializer:(PINDiskCacheDeserializerBlock)deserializer fileExtension:(NSString *)fileExtension {
-    return [self initWithName:name rootPath:rootPath serializer:serializer deserializer:deserializer keyEncoder:nil keyDecoder:nil fileExtension:fileExtension];
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(PINDiskCacheSerializerBlock)serializer deserializer:(PINDiskCacheDeserializerBlock)deserializer {
+    return [self initWithName:name rootPath:rootPath serializer:serializer deserializer:deserializer keyEncoder:nil keyDecoder:nil];
 }
 
 - (instancetype)initWithName:(NSString *)name
@@ -49,7 +44,6 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
                 deserializer:(PINDiskCacheDeserializerBlock)deserializer
                   keyEncoder:(PINDiskCacheKeyEncoderBlock)keyEncoder
                   keyDecoder:(PINDiskCacheKeyDecoderBlock)keyDecoder
-               fileExtension:(NSString *)fileExtension
 {
     if (!name)
         return nil;
@@ -66,7 +60,6 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
                                            deserializer:deserializer
                                              keyEncoder:nil
                                              keyDecoder:nil
-                                          fileExtension:fileExtension
                                          operationQueue:_operationQueue];
         _memoryCache = [[PINMemoryCache alloc] initWithOperationQueue:_operationQueue];
     }

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -39,7 +39,17 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     return [self initWithName:name rootPath:rootPath serializer:nil deserializer:nil fileExtension:fileExtension];
 }
 
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(PINDiskCacheSerializerBlock)serializer deserializer:(PINDiskCacheDeserializerBlock)deserializer fileExtension:(NSString *)fileExtension
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(PINDiskCacheSerializerBlock)serializer deserializer:(PINDiskCacheDeserializerBlock)deserializer fileExtension:(NSString *)fileExtension {
+    return [self initWithName:name rootPath:rootPath serializer:serializer deserializer:deserializer keyEncoder:NULL keyDecoder:NULL fileExtension:fileExtension];
+}
+
+- (instancetype)initWithName:(NSString *)name
+                    rootPath:(NSString *)rootPath
+                  serializer:(PINDiskCacheSerializerBlock)serializer
+                deserializer:(PINDiskCacheDeserializerBlock)deserializer
+                  keyEncoder:(PINDiskCacheKeyEncoderBlock)keyEncoder
+                  keyDecoder:(PINDiskCacheKeyDecoderBlock)keyDecoder
+               fileExtension:(NSString *)fileExtension
 {
     if (!name)
         return nil;
@@ -49,7 +59,15 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
       
         //10 may actually be a bit high, but currently much of our threads are blocked on empyting the trash. Until we can resolve that, lets bump this up.
         _operationQueue = [[PINOperationQueue alloc] initWithMaxConcurrentOperations:10];
-        _diskCache = [[PINDiskCache alloc] initWithName:_name prefix:PINDiskCachePrefix rootPath:rootPath serializer:serializer deserializer:deserializer fileExtension:fileExtension operationQueue:_operationQueue];
+        _diskCache = [[PINDiskCache alloc] initWithName:_name
+                                                 prefix:PINDiskCachePrefix
+                                               rootPath:rootPath
+                                             serializer:serializer
+                                           deserializer:deserializer
+                                             keyEncoder:NULL
+                                             keyDecoder:NULL
+                                          fileExtension:fileExtension
+                                         operationQueue:_operationQueue];
         _memoryCache = [[PINMemoryCache alloc] initWithOperationQueue:_operationQueue];
     }
     return self;

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -40,7 +40,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 }
 
 - (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(PINDiskCacheSerializerBlock)serializer deserializer:(PINDiskCacheDeserializerBlock)deserializer fileExtension:(NSString *)fileExtension {
-    return [self initWithName:name rootPath:rootPath serializer:serializer deserializer:deserializer keyEncoder:NULL keyDecoder:NULL fileExtension:fileExtension];
+    return [self initWithName:name rootPath:rootPath serializer:serializer deserializer:deserializer keyEncoder:nil keyDecoder:nil fileExtension:fileExtension];
 }
 
 - (instancetype)initWithName:(NSString *)name
@@ -64,8 +64,8 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
                                                rootPath:rootPath
                                              serializer:serializer
                                            deserializer:deserializer
-                                             keyEncoder:NULL
-                                             keyDecoder:NULL
+                                             keyEncoder:nil
+                                             keyDecoder:nil
                                           fileExtension:fileExtension
                                          operationQueue:_operationQueue];
         _memoryCache = [[PINMemoryCache alloc] initWithOperationQueue:_operationQueue];

--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -155,11 +155,6 @@ PIN_SUBCLASSING_RESTRICTED
 @property (assign) NSTimeInterval ageLimit;
 
 /**
- Extension for all cache files on disk. Defaults to no extension. 
- */
-@property (nullable, readonly) NSString * fileExtension;
-
-/**
  The writing protection option used when writing a file on disk. This value is used every time an object is set.
  NSDataWritingAtomic and NSDataWritingWithoutOverwriting are ignored if set
  Defaults to NSDataWritingFileProtectionNone.
@@ -251,22 +246,10 @@ PIN_SUBCLASSING_RESTRICTED
  
  @see name
  @param name The name of the cache.
- @param fileExtension The file extension for files on disk.
- @result A new cache with the specified name.
- */
-- (instancetype)initWithName:(nonnull NSString *)name fileExtension:(nullable NSString *)fileExtension;
-
-/**
- Multiple instances with the same name are allowed and can safely access
- the same data on disk thanks to the magic of seriality.
- 
- @see name
- @param name The name of the cache.
  @param rootPath The path of the cache.
- @param fileExtension The file extension for files on disk.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath fileExtension:(nullable NSString *)fileExtension;
+- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath;
 
 /**
  @see name
@@ -274,10 +257,9 @@ PIN_SUBCLASSING_RESTRICTED
  @param rootPath The path of the cache.
  @param serializer   A block used to serialize object. If nil provided, default NSKeyedArchiver serialized will be used.
  @param deserializer A block used to deserialize object. If nil provided, default NSKeyedUnarchiver serialized will be used.
- @param fileExtension The file extension for files on disk.
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer fileExtension:(nullable NSString *)fileExtension;
+- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer;
 
 /**
  The designated initializer allowing you to override default NSKeyedArchiver/NSKeyedUnarchiver serialization.
@@ -287,11 +269,10 @@ PIN_SUBCLASSING_RESTRICTED
  @param rootPath The path of the cache.
  @param serializer   A block used to serialize object. If nil provided, default NSKeyedArchiver serialized will be used.
  @param deserializer A block used to deserialize object. If nil provided, default NSKeyedUnarchiver serialized will be used.
- @param fileExtension The file extension for files on disk.
  @param operationQueue A PINOperationQueue to run asynchronous operations
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer fileExtension:(nullable NSString *)fileExtension operationQueue:(nonnull PINOperationQueue *)operationQueue __attribute__((deprecated));
+- (instancetype)initWithName:(nonnull NSString *)name rootPath:(nonnull NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer operationQueue:(nonnull PINOperationQueue *)operationQueue __attribute__((deprecated));
 
 /**
  The designated initializer allowing you to override default NSKeyedArchiver/NSKeyedUnarchiver serialization.
@@ -304,7 +285,6 @@ PIN_SUBCLASSING_RESTRICTED
  @param deserializer A block used to deserialize object. If nil provided, default NSKeyedUnarchiver serialized will be used.
  @param keyEncoder A block used to encode key(filename). If nil provided, default url encoder will be used
  @param keyDecoder A block used to decode key(filename). If nil provided, default url decoder will be used
- @param fileExtension The file extension for files on disk.
  @param operationQueue A PINOperationQueue to run asynchronous operations
  @result A new cache with the specified name.
  */
@@ -315,7 +295,6 @@ PIN_SUBCLASSING_RESTRICTED
                 deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
                   keyEncoder:(nullable PINDiskCacheKeyEncoderBlock)keyEncoder
                   keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyDecoder
-               fileExtension:(nullable NSString *)fileExtension
               operationQueue:(nonnull PINOperationQueue *)operationQueue NS_DESIGNATED_INITIALIZER;
 
 #pragma mark - Asynchronous Methods

--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -50,6 +50,24 @@ typedef NSData* _Nonnull(^PINDiskCacheSerializerBlock)(id<NSCoding> object, NSSt
  */
 typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSString *key);
 
+/**
+ *  A block used to encode keys
+ *
+ *  @param original/decoded key
+ *
+ *  @return encoded key
+ */
+typedef NSString *_Nonnull(^PINDiskCacheKeyEncoderBlock)(NSString *decodedKey);
+
+/**
+ *  A block used to decode keys
+ *
+ *  @param encoded key
+ *
+ *  @return decoded key
+ */
+typedef NSString *_Nonnull(^PINDiskCacheKeyDecoderBlock)(NSString *encodedKey);
+
 
 /**
  `PINDiskCache` is a thread safe key/value store backed by the file system. It accepts any object conforming
@@ -284,11 +302,21 @@ PIN_SUBCLASSING_RESTRICTED
  @param rootPath The path of the cache.
  @param serializer   A block used to serialize object. If nil provided, default NSKeyedArchiver serialized will be used.
  @param deserializer A block used to deserialize object. If nil provided, default NSKeyedUnarchiver serialized will be used.
+ @param keyEncoder A block used to encode key(filename). If nil provided, default url encoder will be used
+ @param keyDecoder A block used to decode key(filename). If nil provided, default url decoder will be used
  @param fileExtension The file extension for files on disk.
  @param operationQueue A PINOperationQueue to run asynchronous operations
  @result A new cache with the specified name.
  */
-- (instancetype)initWithName:(nonnull NSString *)name prefix:(nonnull NSString *)prefix rootPath:(nonnull NSString *)rootPath serializer:(nullable PINDiskCacheSerializerBlock)serializer deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer fileExtension:(nullable NSString *)fileExtension operationQueue:(nonnull PINOperationQueue *)operationQueue NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithName:(nonnull NSString *)name
+                      prefix:(nonnull NSString *)prefix
+                    rootPath:(nonnull NSString *)rootPath
+                  serializer:(nullable PINDiskCacheSerializerBlock)serializer
+                deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
+                  keyEncoder:(nullable PINDiskCacheKeyEncoderBlock)keyEncoder
+                  keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyEncoder
+               fileExtension:(nullable NSString *)fileExtension
+              operationQueue:(nonnull PINOperationQueue *)operationQueue NS_DESIGNATED_INITIALIZER;
 
 #pragma mark - Asynchronous Methods
 /// @name Asynchronous Methods

--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -53,7 +53,7 @@ typedef id<NSCoding> _Nonnull(^PINDiskCacheDeserializerBlock)(NSData* data, NSSt
 /**
  *  A block used to encode keys
  *
- *  @param original/decoded key
+ *  @param decodedKey Original/decoded key
  *
  *  @return encoded key
  */
@@ -62,7 +62,7 @@ typedef NSString *_Nonnull(^PINDiskCacheKeyEncoderBlock)(NSString *decodedKey);
 /**
  *  A block used to decode keys
  *
- *  @param encoded key
+ *  @param encodedKey An encoded key
  *
  *  @return decoded key
  */
@@ -314,7 +314,7 @@ PIN_SUBCLASSING_RESTRICTED
                   serializer:(nullable PINDiskCacheSerializerBlock)serializer
                 deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
                   keyEncoder:(nullable PINDiskCacheKeyEncoderBlock)keyEncoder
-                  keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyEncoder
+                  keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyDecoder
                fileExtension:(nullable NSString *)fileExtension
               operationQueue:(nonnull PINOperationQueue *)operationQueue NS_DESIGNATED_INITIALIZER;
 

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -84,24 +84,19 @@ static NSURL *_sharedTrashURL;
 
 - (instancetype)initWithName:(NSString *)name
 {
-    return [self initWithName:name fileExtension:nil];
+    return [self initWithName:name rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex:0]];
 }
 
-- (instancetype)initWithName:(NSString *)name fileExtension:(NSString *)fileExtension
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath
 {
-    return [self initWithName:name rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex:0] fileExtension:fileExtension];
+    return [self initWithName:name rootPath:rootPath serializer:nil deserializer:nil];
 }
 
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath fileExtension:(NSString *)fileExtension
-{
-    return [self initWithName:name rootPath:rootPath serializer:nil deserializer:nil fileExtension:fileExtension];
-}
-
-- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(PINDiskCacheSerializerBlock)serializer deserializer:(PINDiskCacheDeserializerBlock)deserializer fileExtension:(NSString *)fileExtension
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath serializer:(PINDiskCacheSerializerBlock)serializer deserializer:(PINDiskCacheDeserializerBlock)deserializer
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return [self initWithName:name rootPath:rootPath serializer:serializer deserializer:deserializer fileExtension:fileExtension operationQueue:[PINOperationQueue sharedOperationQueue]];
+    return [self initWithName:name rootPath:rootPath serializer:serializer deserializer:deserializer operationQueue:[PINOperationQueue sharedOperationQueue]];
 #pragma clang diagnostic pop
 }
 
@@ -109,7 +104,6 @@ static NSURL *_sharedTrashURL;
                     rootPath:(NSString *)rootPath
                   serializer:(PINDiskCacheSerializerBlock)serializer
                 deserializer:(PINDiskCacheDeserializerBlock)deserializer
-               fileExtension:(NSString *)fileExtension
               operationQueue:(PINOperationQueue *)operationQueue
 {
   return [self initWithName:name
@@ -119,7 +113,6 @@ static NSURL *_sharedTrashURL;
                deserializer:deserializer
                  keyEncoder:nil
                  keyDecoder:nil
-              fileExtension:fileExtension
              operationQueue:operationQueue];
 }
 
@@ -130,7 +123,6 @@ static NSURL *_sharedTrashURL;
                 deserializer:(PINDiskCacheDeserializerBlock)deserializer
                   keyEncoder:(PINDiskCacheKeyEncoderBlock)keyEncoder
                   keyDecoder:(PINDiskCacheKeyDecoderBlock)keyDecoder
-               fileExtension:(NSString *)fileExtension
               operationQueue:(PINOperationQueue *)operationQueue
 {
     if (!name)
@@ -146,7 +138,6 @@ static NSURL *_sharedTrashURL;
     if (self = [super init]) {
         _name = [name copy];
         _prefix = [prefix copy];
-        _fileExtension = [fileExtension copy];
         _operationQueue = operationQueue;
         _instanceLock = [[NSConditionLock alloc] initWithCondition:PINDiskCacheConditionNotReady];
         _willAddObjectBlock = nil;
@@ -284,12 +275,7 @@ static NSURL *_sharedTrashURL;
         
         if ([decodedKey respondsToSelector:@selector(stringByAddingPercentEncodingWithAllowedCharacters:)]) {
             NSString *encodedString = [decodedKey stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@".:/%"] invertedSet]];
-            if (self.fileExtension.length > 0) {
-                return [encodedString stringByAppendingPathExtension:self.fileExtension];
-            }
-            else {
-                return encodedString;
-            }
+            return encodedString;
         }
         else {
             CFStringRef static const charsToEscape = CFSTR(".:/%");
@@ -302,12 +288,7 @@ static NSURL *_sharedTrashURL;
                                                                                 kCFStringEncodingUTF8);
 #pragma clang diagnostic pop
             
-            if (self.fileExtension.length > 0) {
-                return [(__bridge_transfer NSString *)escapedString stringByAppendingPathExtension:self.fileExtension];
-            }
-            else {
-                return (__bridge_transfer NSString *)escapedString;
-            }
+            return (__bridge_transfer NSString *)escapedString;
         }
     };
 }

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -117,8 +117,8 @@ static NSURL *_sharedTrashURL;
                    rootPath:rootPath
                  serializer:serializer
                deserializer:deserializer
-               keyEncoder:NULL
-               keyDecoder:NULL
+                 keyEncoder:nil
+                 keyDecoder:nil
               fileExtension:fileExtension
              operationQueue:operationQueue];
 }
@@ -128,25 +128,20 @@ static NSURL *_sharedTrashURL;
                     rootPath:(NSString *)rootPath
                   serializer:(PINDiskCacheSerializerBlock)serializer
                 deserializer:(PINDiskCacheDeserializerBlock)deserializer
-                keyEncoder:(PINDiskCacheKeyEncoderBlock)keyEncoder
-                keyDecoder:(PINDiskCacheKeyDecoderBlock)keyDecoder
+                  keyEncoder:(PINDiskCacheKeyEncoderBlock)keyEncoder
+                  keyDecoder:(PINDiskCacheKeyDecoderBlock)keyDecoder
                fileExtension:(NSString *)fileExtension
               operationQueue:(PINOperationQueue *)operationQueue
 {
     if (!name)
         return nil;
     
-    if ((serializer && !deserializer) ||
-        (!serializer && deserializer)){
-        @throw [NSException exceptionWithName:@"Must initialize with a both serializer and deserializer" reason:@"PINDiskCache must be initialized with a serializer and deserializer." userInfo:nil];
-        return nil;
-    }
+
+    NSAssert(((!serializer && !deserializer) || (serializer && deserializer)),
+             @"PINDiskCache must be initialized with a serializer AND deserializer.");
     
-    if ((keyEncoder && !keyDecoder) ||
-        (!keyEncoder && keyDecoder)){
-        @throw [NSException exceptionWithName:@"Must initialize with a both encoder and decoder" reason:@"PINDiskCache must be initialized with a encoder and decoder." userInfo:nil];
-        return nil;
-    }
+    NSAssert(((!keyEncoder && !keyDecoder) || (keyEncoder && keyDecoder)),
+              @"PINDiskCache must be initialized with a encoder AND decoder.");
     
     if (self = [super init]) {
         _name = [name copy];

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -881,28 +881,6 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:[testCacheURL path]]);
 }
 
-- (void)testCustomFileExtension {
-    
-    PINCache *cache = [[PINCache alloc] initWithName:[[NSUUID UUID] UUIDString] fileExtension:@"obj"];
-    
-    NSString *key = @"key";
-    __block NSURL *diskFileURL = nil;
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-    
-    [cache.diskCache setObjectAsync:[self image] forKey:key completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
-        [cache fileURLForKeyAsync:key completion:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {
-            diskFileURL = fileURL;
-            dispatch_semaphore_signal(semaphore);
-        }];
-    }];
-    
-    dispatch_semaphore_wait(semaphore, [self timeout]);
-    
-    XCTAssertNotNil(diskFileURL.pathExtension);
-    XCTAssertEqualObjects(diskFileURL.pathExtension, @"obj");
-    
-}
-
 - (void)testDiskCacheSet
 {
   PINDiskCache *testCache = [[PINDiskCache alloc] initWithName:@"testDiskCacheSet"];
@@ -996,7 +974,6 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
                                                     deserializer:NULL
                                                       keyEncoder:encoder
                                                       keyDecoder:decoder
-                                                   fileExtension:NULL
                                                   operationQueue:[PINOperationQueue sharedOperationQueue]];
     
     [testCache setObject:@(1) forKey:@"test_key"];


### PR DESCRIPTION
Hi.
First, thanks for an amazing project. We are using ASDK and PINRemoteImage extensively in our app. We started to use PINCache as separate cache and there are cases when we want our custom filenames. We have added block for custom custom encoding/decoding, so anyone can provide their implementation for filenames. This can be used also for file extensions. Maybe in the next version extension can be replaced with custom blocks. Please let us know if it’s okey to merge. 
Thanks.
