### PR TITLE
[PINDiskCache] Respect small byteLimit settings by checking object size in setObject:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add your own contributions to the next release on the line below this with your name.
 
 ## 3.0.1 -- Beta 5
+- [fix] Respect small byteLimit settings by checking object size in setObject: [#198](https://github.com/pinterest/PINCache/pull/198)
 - [new] Added an ability to set custom encoder/decoder for file names: [#192](https://github.com/pinterest/PINCache/pull/192)
 
 ## 2.2.1 -- 2016 Mar 5

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -838,7 +838,7 @@ static NSURL *_sharedTrashURL;
 {
     NSDate *now = [[NSDate alloc] init];
     
-    if (!key)
+    if (!key || (_dates.count == 0 && _sizes.count == 0))
         return nil;
     
     id <NSCoding> object = nil;

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -936,8 +936,23 @@ static NSURL *_sharedTrashURL;
       NSDataWritingOptions writeOptions = NSDataWritingAtomic;
     #endif
   
-    NSURL *fileURL = [self encodedFileURLForKey:key];
-    
+    // Remain unlocked here so that we're not locked while serializing.
+    NSData *data = _serializer(object, key);
+    NSURL *fileURL = nil;
+
+    NSUInteger byteLimit = self.byteLimit;
+    if (data.length <= byteLimit || byteLimit == 0) {
+        // The cache is large enough to fit this object (although we may need to evict others).
+        fileURL = [self encodedFileURLForKey:key];
+    } else {
+        // The cache isn't large enough to fit this object (even if all others were evicted).
+        // We should not write it to disk because it will be deleted immediately after.
+        if (outFileURL) {
+            *outFileURL = nil;
+        }
+        return;
+    }
+
     [self lock];
         PINCacheObjectBlock willAddObjectBlock = self->_willAddObjectBlock;
         if (willAddObjectBlock) {
@@ -946,13 +961,7 @@ static NSURL *_sharedTrashURL;
             [self lock];
         }
     
-        //We unlock here so that we're not locked while serializing.
-        [self unlock];
-            NSData *data = _serializer(object, key);
-        [self lock];
-    
         NSError *writeError = nil;
-  
         BOOL written = [data writeToURL:fileURL options:writeOptions error:&writeError];
         PINDiskCacheError(writeError);
         

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -838,7 +838,11 @@ static NSURL *_sharedTrashURL;
 {
     NSDate *now = [[NSDate alloc] init];
     
-    if (!key || (_dates.count == 0 && _sizes.count == 0))
+    [self lock];
+        BOOL isEmpty = (_dates.count == 0 && _sizes.count == 0);
+    [self unlock];
+
+    if (!key || isEmpty)
         return nil;
     
     id <NSCoding> object = nil;

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -877,7 +877,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     
     testCache = [[PINDiskCache alloc] initWithName:cacheName];
     //This should not return until *after* disk cache directory has been created
-    [testCache objectForKey:@"some bogus key"];
+    [testCache setObject:[NSNumber numberWithInt:1] forKey:@"some bogus key"];
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:[testCacheURL path]]);
 }
 

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -877,7 +877,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     
     testCache = [[PINDiskCache alloc] initWithName:cacheName];
     //This should not return until *after* disk cache directory has been created
-    [testCache setObject:[NSNumber numberWithInt:1] forKey:@"some bogus key"];
+    [testCache objectForKey:@"some bogus key"];
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:[testCacheURL path]]);
 }
 


### PR DESCRIPTION
This serves as a mechanism for some clients, like users of the Texture framework, to
effectively disable the PINDiskCache by setting a byteLimit of 1.

Before this change, the cache would transiently exceed the byte limit by writing
the file anyway, and then immediately deleting it.

This change will not affect most users of PINDiskCache, but is important for this
specific use case.