### PR TITLE
Added supporting for observing changes happening in the cache

### DIFF
--- a/PINCache.xcodeproj/project.pbxproj
+++ b/PINCache.xcodeproj/project.pbxproj
@@ -46,6 +46,15 @@
 		CC0106C81E28226A00890935 /* PINCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC01060D1E271A9000890935 /* PINCacheTests.m */; };
 		CC0106CD1E28249C00890935 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = CC0106CA1E28248800890935 /* Default-568h@2x.png */; };
 		CC0106CE1E28249D00890935 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = CC0106CA1E28248800890935 /* Default-568h@2x.png */; };
+		CDF3EB761FBE35B00055035A /* PINCacheKeyObserverManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF3EB741FBE35B00055035A /* PINCacheKeyObserverManager.h */; };
+		CDF3EB771FBE35B00055035A /* PINCacheKeyObserverManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF3EB741FBE35B00055035A /* PINCacheKeyObserverManager.h */; };
+		CDF3EB781FBE35B00055035A /* PINCacheKeyObserverManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF3EB741FBE35B00055035A /* PINCacheKeyObserverManager.h */; };
+		CDF3EB791FBE35B00055035A /* PINCacheKeyObserverManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CDF3EB751FBE35B00055035A /* PINCacheKeyObserverManager.m */; };
+		CDF3EB7A1FBE35B00055035A /* PINCacheKeyObserverManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CDF3EB751FBE35B00055035A /* PINCacheKeyObserverManager.m */; };
+		CDF3EB7B1FBE35B00055035A /* PINCacheKeyObserverManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CDF3EB751FBE35B00055035A /* PINCacheKeyObserverManager.m */; };
+		CDF3EB7D1FBE35CC0055035A /* PINCacheKeyObserving.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF3EB7C1FBE35CC0055035A /* PINCacheKeyObserving.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CDF3EB7E1FBE35CC0055035A /* PINCacheKeyObserving.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF3EB7C1FBE35CC0055035A /* PINCacheKeyObserving.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CDF3EB7F1FBE35CC0055035A /* PINCacheKeyObserving.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF3EB7C1FBE35CC0055035A /* PINCacheKeyObserving.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -190,6 +199,9 @@
 		CC0106C51E281D6900890935 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CC0106C91E28228300890935 /* PINCacheTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheTests.h; sourceTree = "<group>"; };
 		CC0106CA1E28248800890935 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
+		CDF3EB741FBE35B00055035A /* PINCacheKeyObserverManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheKeyObserverManager.h; sourceTree = "<group>"; };
+		CDF3EB751FBE35B00055035A /* PINCacheKeyObserverManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINCacheKeyObserverManager.m; sourceTree = "<group>"; };
+		CDF3EB7C1FBE35CC0055035A /* PINCacheKeyObserving.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheKeyObserving.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -301,6 +313,9 @@
 				CC0106071E271A9000890935 /* PINCacheObjectSubscripting.h */,
 				CC0106081E271A9000890935 /* PINDiskCache.h */,
 				CC0106091E271A9000890935 /* PINDiskCache.m */,
+				CDF3EB741FBE35B00055035A /* PINCacheKeyObserverManager.h */,
+				CDF3EB751FBE35B00055035A /* PINCacheKeyObserverManager.m */,
+				CDF3EB7C1FBE35CC0055035A /* PINCacheKeyObserving.h */,
 				CC01060A1E271A9000890935 /* PINMemoryCache.h */,
 				CC01060B1E271A9000890935 /* PINMemoryCache.m */,
 				68A0FBFF1E4D3282000B552D /* PINCacheMacros.h */,
@@ -335,11 +350,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				6928EED31E4160EE00B5D975 /* PINCaching.h in Headers */,
+				CDF3EB761FBE35B00055035A /* PINCacheKeyObserverManager.h in Headers */,
 				CC0106171E271AAF00890935 /* PINCache.h in Headers */,
 				68A0FC001E4D32C4000B552D /* PINCacheMacros.h in Headers */,
 				CC0106181E271AAF00890935 /* PINCacheObjectSubscripting.h in Headers */,
 				CC01061A1E271AAF00890935 /* PINMemoryCache.h in Headers */,
 				CC0106191E271AAF00890935 /* PINDiskCache.h in Headers */,
+				CDF3EB7D1FBE35CC0055035A /* PINCacheKeyObserving.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -348,11 +365,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				6928EED41E4160FE00B5D975 /* PINCaching.h in Headers */,
+				CDF3EB771FBE35B00055035A /* PINCacheKeyObserverManager.h in Headers */,
 				CC01061B1E271AB000890935 /* PINCache.h in Headers */,
 				68A0FC011E4D32C6000B552D /* PINCacheMacros.h in Headers */,
 				CC01061C1E271AB000890935 /* PINCacheObjectSubscripting.h in Headers */,
 				CC01061E1E271AB000890935 /* PINMemoryCache.h in Headers */,
 				CC01061D1E271AB000890935 /* PINDiskCache.h in Headers */,
+				CDF3EB7E1FBE35CC0055035A /* PINCacheKeyObserving.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -361,11 +380,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				6928EED51E41610700B5D975 /* PINCaching.h in Headers */,
+				CDF3EB781FBE35B00055035A /* PINCacheKeyObserverManager.h in Headers */,
 				CC01061F1E271AB000890935 /* PINCache.h in Headers */,
 				68A0FC021E4D32C7000B552D /* PINCacheMacros.h in Headers */,
 				CC0106201E271AB000890935 /* PINCacheObjectSubscripting.h in Headers */,
 				CC0106221E271AB000890935 /* PINMemoryCache.h in Headers */,
 				CC0106211E271AB000890935 /* PINDiskCache.h in Headers */,
+				CDF3EB7F1FBE35CC0055035A /* PINCacheKeyObserving.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -643,6 +664,7 @@
 			files = (
 				CC01060E1E271A9500890935 /* PINCache.m in Sources */,
 				CC0106101E271A9500890935 /* PINMemoryCache.m in Sources */,
+				CDF3EB791FBE35B00055035A /* PINCacheKeyObserverManager.m in Sources */,
 				CC01060F1E271A9500890935 /* PINDiskCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -653,6 +675,7 @@
 			files = (
 				CC0106111E271A9600890935 /* PINCache.m in Sources */,
 				CC0106131E271A9600890935 /* PINMemoryCache.m in Sources */,
+				CDF3EB7A1FBE35B00055035A /* PINCacheKeyObserverManager.m in Sources */,
 				CC0106121E271A9600890935 /* PINDiskCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -663,6 +686,7 @@
 			files = (
 				CC0106141E271A9700890935 /* PINCache.m in Sources */,
 				CC0106161E271A9700890935 /* PINMemoryCache.m in Sources */,
+				CDF3EB7B1FBE35B00055035A /* PINCacheKeyObserverManager.m in Sources */,
 				CC0106151E271A9700890935 /* PINDiskCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -5,6 +5,7 @@
 #import <Foundation/Foundation.h>
 
 #import <PINCache/PINCacheMacros.h>
+#import <PINCache/PINCacheKeyObserving.h>
 #import <PINCache/PINCaching.h>
 #import <PINCache/PINDiskCache.h>
 #import <PINCache/PINMemoryCache.h>
@@ -32,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 
 PIN_SUBCLASSING_RESTRICTED
-@interface PINCache : NSObject <PINCaching, PINCacheObjectSubscripting>
+@interface PINCache : NSObject <PINCaching, PINCacheKeyObserving, PINCacheObjectSubscripting>
 
 #pragma mark -
 /// @name Core

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -4,6 +4,7 @@
 
 #import "PINCache.h"
 
+#import <PINCache/PINCacheKeyObserverManager.h>
 #import <PINOperation/PINOperation.h>
 
 static NSString * const PINCachePrefix = @"com.pinterest.PINCache";
@@ -12,6 +13,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 @interface PINCache ()
 @property (copy, nonatomic) NSString *name;
 @property (strong, nonatomic) PINOperationQueue *operationQueue;
+@property (strong, nonatomic) PINCacheKeyObserverManager *observerManager;
 @end
 
 @implementation PINCache
@@ -62,6 +64,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
                                              keyDecoder:nil
                                          operationQueue:_operationQueue];
         _memoryCache = [[PINMemoryCache alloc] initWithOperationQueue:_operationQueue];
+        _observerManager = [[PINCacheKeyObserverManager alloc] initWithCache:self];
     }
     return self;
 }
@@ -147,12 +150,13 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [group addOperation:^{
         [_diskCache setObject:object forKey:key];
     }];
-  
-    if (block) {
-        [group setCompletion:^{
+    
+    [group setCompletion:^{
+        [_observerManager updatedKey:key withValue:object];
+        if (block) {
             block(self, key, object);
-        }];
-    }
+        }
+    }];
     
     [group start];
 }
@@ -170,12 +174,13 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [group addOperation:^{
         [_diskCache removeObjectForKey:key];
     }];
-
-    if (block) {
-        [group setCompletion:^{
+    
+    [group setCompletion:^{
+        [_observerManager deletedValueForKey:key];
+        if (block) {
             block(self, key, nil);
-        }];
-    }
+        }
+    }];
     
     [group start];
 }
@@ -190,12 +195,13 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     [group addOperation:^{
         [_diskCache removeAllObjects];
     }];
-
-    if (block) {
-        [group setCompletion:^{
+    
+    [group setCompletion:^{
+        if (block) {
             block(self);
-        }];
-    }
+        }
+        [_observerManager deletedAllValues];
+    }];
     
     [group start];
 }
@@ -276,6 +282,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
     
     [_memoryCache setObject:object forKey:key withCost:cost];
     [_diskCache setObject:object forKey:key];
+    [_observerManager updatedKey:key withValue:object];
 }
 
 - (nullable id)objectForKeyedSubscript:(NSString *)key
@@ -314,6 +321,17 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 {
     [_memoryCache removeAllObjects];
     [_diskCache removeAllObjects];
+    [_observerManager deletedAllValues];
+}
+
+- (void)addObserver:(id)observer selector:(SEL)selector forKey:(NSString *)key
+{
+    [self.observerManager addObserver:observer selector:selector forKey:key];
+}
+
+- (void)removeObserver:(id)observer forKey:(nonnull NSString *)key
+{
+    [self.observerManager removeObserver:observer forKey:key];
 }
 
 @end

--- a/Source/PINCacheKeyObserverManager.h
+++ b/Source/PINCacheKeyObserverManager.h
@@ -1,0 +1,58 @@
+//
+//  PINCacheKeyObserverManager.h
+//  PINCache
+//
+//  Created by Rocir Santiago on 11/16/17.
+//  Copyright © 2017 Pinterest. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import <PINCache/PINCacheKeyObserving.h>
+#import <PINCache/PINCaching.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString * const PINCacheKeyChangedName;
+extern NSString * const PINCacheKeyChangedValue;
+extern NSString * const PINCacheKeyChangedCache;
+
+/**
+ * `PINCacheKeyObserverManager` is a class designed for handling key observing with PINCache. It can
+ * be used with any class conforming to `PINCaching`. By default, `PINCache`, `PINMemoryCache` and
+ * `PINDiskCache` already use it.
+ */
+@interface PINCacheKeyObserverManager : NSObject <PINCacheKeyObserving>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * Creates a new instance of `PINCacheObserverManager`.
+ *
+ * @param cache The cache instance to which the manager will handle key/value changes.
+ */
+- (instancetype)initWithCache:(id<PINCaching>)cache NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Should be called when a value for a key in the cache has been added or updated.
+ *
+ * @param key The key which value has been updated.
+ * @param value The new value associated with the key.
+ */
+- (void)updatedKey:(NSString *)key withValue:(nullable id)value;
+
+/**
+ * Should be called when a given value for a key has been removed from the cache.
+ *
+ * @param key The key which value has been removed from the cache.
+ */
+- (void)deletedValueForKey:(NSString *)key;
+
+/**
+ * Should be called when all the values in the cache have been removed.
+ */
+- (void)deletedAllValues;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PINCacheKeyObserverManager.m
+++ b/Source/PINCacheKeyObserverManager.m
@@ -1,0 +1,147 @@
+//
+//  PINCacheKeyObserverManager.m
+//  PINCache
+//
+//  Created by Rocir Santiago on 11/16/17.
+//  Copyright © 2017 Pinterest. All rights reserved.
+//
+
+#import "PINCacheKeyObserverManager.h"
+
+#import <PINCache/PINCache.h>
+
+NSString * const PINCacheKeyChangedName = @"PINCacheKeyChangedName";
+NSString * const PINCacheKeyChangedValue = @"PINCacheKeyChangedValue";
+NSString * const PINCacheKeyChangedCache = @"PINCacheKeyChangedCache";
+
+static NSString * const PINCacheKeyChangedNotificationFormat = @"PINCacheKeyChanged.%@";
+
+@interface PINCacheKeyObserverManager ()
+@property (weak, nonatomic) id<PINCaching> cache;
+@property (strong, nonatomic) NSMutableDictionary<NSString *, NSMutableSet<id> *> *keysToObserversMapping;
+@property (strong, nonatomic) dispatch_queue_t queue;
+// We have our own notification center instead of the default one so removing them from the center doesn't conflict with anything non PINCache related.
+@property (strong, nonatomic) NSNotificationCenter *observersNotificationCenter;
+@end
+
+@implementation PINCacheKeyObserverManager
+
+#pragma mark - Initialization
+
+- (instancetype)initWithCache:(id<PINCaching>)cache
+{
+    self = [super init];
+    if (self) {
+        _cache = cache;
+        _keysToObserversMapping = [[NSMutableDictionary alloc] init];
+        NSString *queueName = [NSString stringWithFormat:@"%@.key_observer_manager", PINDiskCachePrefix];
+        _queue = dispatch_queue_create([queueName UTF8String], DISPATCH_QUEUE_SERIAL);
+        _observersNotificationCenter = [[NSNotificationCenter alloc] init];
+    }
+    return self;
+}
+
+#pragma mark - Public methods
+
+- (void)updatedKey:(NSString *)key withValue:(id)value
+{
+    dispatch_async(_queue, ^{
+        if (key.length == 0 || ![self isTrackingKey:key]) {
+            return;
+        }
+        
+        NSDictionary *userInfo = [self userInfoForKey:key withValue:value];
+        [_observersNotificationCenter postNotificationName:[self notificationNameForKey:key]
+                                                    object:nil
+                                                  userInfo:userInfo];
+    });
+}
+
+- (void)deletedValueForKey:(NSString *)key
+{
+    dispatch_async(_queue, ^{
+        if (key.length == 0 || ![self isTrackingKey:key]) {
+            return;
+        }
+        
+        NSDictionary *userInfo = [self userInfoForKey:key withValue:nil];
+        [_observersNotificationCenter postNotificationName:[self notificationNameForKey:key]
+                                                    object:nil
+                                                  userInfo:userInfo];
+    });
+}
+
+- (void)deletedAllValues
+{
+    for (NSString *key in [_keysToObserversMapping allKeys]) {
+        [self deletedValueForKey:key];
+    }
+}
+
+#pragma mark - PINCacheKeyObserving
+
+- (void)addObserver:(id)observer selector:(SEL)selector forKey:(NSString *)key
+{
+    if (key.length == 0) {
+        return;
+    }
+    
+    dispatch_async(_queue, ^{
+        [_observersNotificationCenter addObserver:observer
+                                         selector:selector
+                                             name:[self notificationNameForKey:key]
+                                           object:nil];
+        
+        NSMutableSet<id> *observers = _keysToObserversMapping[key];
+        if (observers == nil) {
+            observers = [[NSMutableSet alloc] init];
+            _keysToObserversMapping[key] = observers;
+        }
+        [observers addObject:observer];
+        
+    });
+}
+
+- (void)removeObserver:(id)observer forKey:(NSString *)key
+{
+    if (key.length == 0) {
+        return;
+    }
+    
+    dispatch_async(_queue, ^{
+        [_observersNotificationCenter removeObserver:observer
+                                                name:[self notificationNameForKey:key]
+                                              object:nil];
+        
+        NSMutableSet<id> *observers = _keysToObserversMapping[key];
+        [observers removeObject:observer];
+    });
+}
+
+#pragma mark - Private
+
+- (BOOL)isTrackingKey:(NSString *)key
+{
+    NSSet<id> *set = _keysToObserversMapping[key];
+    return set.count > 0;
+}
+
+- (NSString *)notificationNameForKey:(NSString *)key
+{
+    return [NSString stringWithFormat:PINCacheKeyChangedNotificationFormat, key];
+}
+
+- (NSDictionary *)userInfoForKey:(NSString *)key withValue:(id)value
+{
+    NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    userInfo[PINCacheKeyChangedName] = key;
+    if (value != nil) {
+        userInfo[PINCacheKeyChangedValue] = value;
+    }
+    if (self.cache) {
+        userInfo[PINCacheKeyChangedCache] = self.cache;
+    }
+    return userInfo;
+}
+
+@end

--- a/Source/PINCacheKeyObserving.h
+++ b/Source/PINCacheKeyObserving.h
@@ -1,0 +1,37 @@
+//
+//  PINCacheKeyObserving.h
+//  PINCache
+//
+//  Created by Rocir Santiago on 11/16/17.
+//  Copyright © 2017 Pinterest. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol PINCacheKeyObserving <NSObject>
+
+@required
+
+/**
+ * Adds an observer for every time the value of a given key has been added, changed or removed from
+ * the cache.
+ *
+ * @param observer The object that will act as the observer.
+ * @param selector The callback for when a key/value is changed or removed.
+ * @param key The key for which changes are being observed.
+ */
+- (void)addObserver:(id)observer selector:(SEL)selector forKey:(NSString *)key;
+
+/**
+ * Removes an object as an observer from key/value changes.
+ *
+ * @param observer The object to stop acting as an observer for a given key.
+ * @param key The key to which the object shouldn't observe to changes anymore.
+ */
+- (void)removeObserver:(id)observer forKey:(NSString *)key;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -4,6 +4,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import <PINCache/PINCacheKeyObserving.h>
 #import <PINCache/PINCacheMacros.h>
 #import <PINCache/PINCaching.h>
 #import <PINCache/PINCacheObjectSubscripting.h>
@@ -99,7 +100,7 @@ typedef NSString *_Nonnull(^PINDiskCacheKeyDecoderBlock)(NSString *encodedKey);
  */
 
 PIN_SUBCLASSING_RESTRICTED
-@interface PINDiskCache : NSObject <PINCaching, PINCacheObjectSubscripting>
+@interface PINDiskCache : NSObject <PINCaching, PINCacheKeyObserving, PINCacheObjectSubscripting>
 
 #pragma mark - Class
 

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -10,6 +10,7 @@
 
 #import <pthread.h>
 
+#import <PINCache/PINCacheKeyObserverManager.h>
 #import <PINOperation/PINOperation.h>
 
 #define PINDiskCacheError(error) if (error) { NSLog(@"%@ (%d) ERROR: %@", \
@@ -63,6 +64,7 @@ static PINOperationDataCoalescingBlock PINDiskTrimmingDateCoalescingBlock = ^id(
 @property (assign, nonatomic) BOOL diskWritable;
 @property (assign, nonatomic) pthread_cond_t diskStateKnownCondition;
 @property (assign, nonatomic) BOOL diskStateKnown;
+@property (strong, nonatomic) PINCacheKeyObserverManager *observerManager;
 @end
 
 @implementation PINDiskCache
@@ -165,6 +167,8 @@ static NSURL *_sharedTrashURL;
         _didAddObjectBlock = nil;
         _didRemoveObjectBlock = nil;
         _didRemoveAllObjectsBlock = nil;
+        
+        _observerManager = [[PINCacheKeyObserverManager alloc] initWithCache:self];
         
         _byteCount = 0;
         
@@ -571,6 +575,8 @@ static NSURL *_sharedTrashURL;
         }
     
     [self unlock];
+    
+    [_observerManager deletedValueForKey:key];
     
     return YES;
 }
@@ -1038,7 +1044,10 @@ static NSURL *_sharedTrashURL;
                 didAddObjectBlock(self, key, object);
             [self lock];
         }
+    
     [self unlock];
+    
+    [self.observerManager updatedKey:key withValue:object];
     
     if (outFileURL) {
         *outFileURL = fileURL;
@@ -1148,6 +1157,16 @@ static NSURL *_sharedTrashURL;
             }
         }
     [self unlock];
+}
+
+- (void)addObserver:(id)observer selector:(SEL)selector forKey:(NSString *)key;
+{
+    [_observerManager addObserver:observer selector:selector forKey:key];
+}
+
+- (void)removeObserver:(id)observer forKey:(NSString *)key
+{
+    [_observerManager removeObserver:observer forKey:key];
 }
 
 #pragma mark - Public Thread Safe Accessors -

--- a/Source/PINMemoryCache.h
+++ b/Source/PINMemoryCache.h
@@ -4,6 +4,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import <PINCache/PINCacheKeyObserving.h>
 #import <PINCache/PINCacheMacros.h>
 #import <PINCache/PINCaching.h>
 #import <PINCache/PINCacheObjectSubscripting.h>
@@ -32,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 
 PIN_SUBCLASSING_RESTRICTED
-@interface PINMemoryCache : NSObject <PINCaching, PINCacheObjectSubscripting>
+@interface PINMemoryCache : NSObject <PINCaching, PINCacheKeyObserving, PINCacheObjectSubscripting>
 
 #pragma mark - Properties
 /// @name Core


### PR DESCRIPTION
This is a proposal to address https://github.com/pinterest/PINCache/issues/207.

This PR adds the ability to add and remove objects as observers for a given key in any of the caches (`PINCache`, `PINMemoryCache` and `PINDiskCache`). Once observing, the desired selector will be called and some metadata, such as changed key, value (if not deleted) is passed in the notification's `userInfo`.