### PR TITLE
Fix warnings related to a wrong param name on a documentation function and referencing self within a block

### DIFF
--- a/PINCache/PINCacheObjectSubscripting.h
+++ b/PINCache/PINCacheObjectSubscripting.h
@@ -23,7 +23,7 @@
 /**
  This method enables using literals on the receiving object, such as `cache[@"key"] = object;`.
  
- @param object An object to be assigned for the key.
+ @param obj An object to be assigned for the key.
  @param key A key to associate with the object. This string will be copied.
  */
 - (void)setObject:(id)obj forKeyedSubscript:(NSString *)key;

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -115,12 +115,11 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         //we don't want to do anything without setting up the disk cache, but we also don't want to block init, it can take a while to initialize
         __weak typeof(self) weakSelf = self;
         dispatch_async(_asyncQueue, ^{
-            __strong typeof(self) strongSelf = weakSelf;
             //should always be able to aquire the lock unless the below code is running.
-            [strongSelf->_instanceLock lockWhenCondition:PINDiskCacheConditionNotReady];
+            [self->_instanceLock lockWhenCondition:PINDiskCacheConditionNotReady];
             [weakSelf createCacheDirectory];
             [weakSelf initializeDiskProperties];
-            [strongSelf->_instanceLock unlockWithCondition:PINDiskCacheConditionReady];
+            [self->_instanceLock unlockWithCondition:PINDiskCacheConditionReady];
         });
     }
     return self;

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -113,12 +113,11 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         _cacheURL = [NSURL fileURLWithPathComponents:@[ rootPath, pathComponent ]];
         
         //we don't want to do anything without setting up the disk cache, but we also don't want to block init, it can take a while to initialize
-        __weak typeof(self) weakSelf = self;
         dispatch_async(_asyncQueue, ^{
             //should always be able to aquire the lock unless the below code is running.
             [self->_instanceLock lockWhenCondition:PINDiskCacheConditionNotReady];
-            [weakSelf createCacheDirectory];
-            [weakSelf initializeDiskProperties];
+            [self createCacheDirectory];
+            [self initializeDiskProperties];
             [self->_instanceLock unlockWithCondition:PINDiskCacheConditionReady];
         });
     }

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -115,11 +115,12 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         //we don't want to do anything without setting up the disk cache, but we also don't want to block init, it can take a while to initialize
         __weak typeof(self) weakSelf = self;
         dispatch_async(_asyncQueue, ^{
+            __strong typeof(self) strongSelf = weakSelf;
             //should always be able to aquire the lock unless the below code is running.
-            [self->_instanceLock lockWhenCondition:PINDiskCacheConditionNotReady];
+            [strongSelf->_instanceLock lockWhenCondition:PINDiskCacheConditionNotReady];
             [weakSelf createCacheDirectory];
             [weakSelf initializeDiskProperties];
-            [self->_instanceLock unlockWithCondition:PINDiskCacheConditionReady];
+            [strongSelf->_instanceLock unlockWithCondition:PINDiskCacheConditionReady];
         });
     }
     return self;

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -113,12 +113,13 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         _cacheURL = [NSURL fileURLWithPathComponents:@[ rootPath, pathComponent ]];
         
         //we don't want to do anything without setting up the disk cache, but we also don't want to block init, it can take a while to initialize
+        __weak typeof(self) weakSelf = self;
         dispatch_async(_asyncQueue, ^{
             //should always be able to aquire the lock unless the below code is running.
-            [_instanceLock lockWhenCondition:PINDiskCacheConditionNotReady];
-                [self createCacheDirectory];
-                [self initializeDiskProperties];
-            [_instanceLock unlockWithCondition:PINDiskCacheConditionReady];
+            [weakSelf.instanceLock lockWhenCondition:PINDiskCacheConditionNotReady];
+            [weakSelf createCacheDirectory];
+            [weakSelf initializeDiskProperties];
+            [weakSelf.instanceLock unlockWithCondition:PINDiskCacheConditionReady];
         });
     }
     return self;

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -116,10 +116,10 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         __weak typeof(self) weakSelf = self;
         dispatch_async(_asyncQueue, ^{
             //should always be able to aquire the lock unless the below code is running.
-            [_instanceLock lockWhenCondition:PINDiskCacheConditionNotReady];
+            [self->_instanceLock lockWhenCondition:PINDiskCacheConditionNotReady];
             [weakSelf createCacheDirectory];
             [weakSelf initializeDiskProperties];
-            [_instanceLock unlockWithCondition:PINDiskCacheConditionReady];
+            [self->_instanceLock unlockWithCondition:PINDiskCacheConditionReady];
         });
     }
     return self;

--- a/PINCache/PINDiskCache.m
+++ b/PINCache/PINDiskCache.m
@@ -116,10 +116,10 @@ typedef NS_ENUM(NSUInteger, PINDiskCacheCondition) {
         __weak typeof(self) weakSelf = self;
         dispatch_async(_asyncQueue, ^{
             //should always be able to aquire the lock unless the below code is running.
-            [weakSelf.instanceLock lockWhenCondition:PINDiskCacheConditionNotReady];
+            [_instanceLock lockWhenCondition:PINDiskCacheConditionNotReady];
             [weakSelf createCacheDirectory];
             [weakSelf initializeDiskProperties];
-            [weakSelf.instanceLock unlockWithCondition:PINDiskCacheConditionReady];
+            [_instanceLock unlockWithCondition:PINDiskCacheConditionReady];
         });
     }
     return self;


### PR DESCRIPTION
## Fix warnings related to a wrong param name on a documentation function and referencing self within a block

- fixes retain cycle warning (calling self inside a block)
- fix warning in block declaration
