### PR TITLE
Fix mem cache TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this with your name.
-- [fix] Fix PINMemoryCache to check if TTL before updating last fetched date: [#222](https://github.com/pinterest/PINCache/pull/222) (jerelevine)
+- [fix] Fix PINMemoryCache to check TTL before updating last fetched date: [#222](https://github.com/pinterest/PINCache/pull/222) (jerelevine)
 - [fix] Fix up warnings and upgrade to PINOperation 1.1.1: [#213](https://github.com/pinterest/PINCache/pull/213)
 - [performance] Reduce locking churn in cleanup methods. [#212](https://github.com/pinterest/PINCache/pull/212)
 - [fix] Don't set file protection unless requested. [#220](https://github.com/pinterest/PINCache/pull/220)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this with your name.
+- [fix] Fix PINMemoryCache to check if TTL before updating last fetched date: [#222](https://github.com/pinterest/PINCache/pull/222) (jerelevine)
 - [fix] Fix up warnings and upgrade to PINOperation 1.1.1: [#213](https://github.com/pinterest/PINCache/pull/213)
 - [performance] Reduce locking churn in cleanup methods. [#212](https://github.com/pinterest/PINCache/pull/212)
 - [fix] Don't set file protection unless requested. [#220](https://github.com/pinterest/PINCache/pull/220)

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -383,20 +383,17 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
         return nil;
     
     NSDate *now = [[NSDate alloc] init];
+    id object = nil;
     [self lock];
-        id object = nil;
         // If the cache should behave like a TTL cache, then only fetch the object if there's a valid ageLimit and  the object is still alive
         if (!self->_ttlCache || self->_ageLimit <= 0 || fabs([[_dates objectForKey:key] timeIntervalSinceDate:now]) < self->_ageLimit) {
             object = _dictionary[key];
         }
-    [self unlock];
-        
-    if (object) {
-        [self lock];
+        if (object && !self->_ttlCache) {
             _dates[key] = now;
-        [self unlock];
-    }
-
+        }
+    [self unlock];
+    
     return object;
 }
 


### PR DESCRIPTION
This fixes an issue where the memory cache was updating the last fetched date even when the cache is using TTL. The disk cache works this way and the memory cache should function in a comparable way.