### PR TITLE
Resolve warnings in Xcode 10

### DIFF
--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -982,7 +982,7 @@ static NSURL *_sharedTrashURL;
 
 #pragma mark - Public Synchronous Methods -
 
-- (void)synchronouslyLockFileAccessWhileExecutingBlock:(PINCacheBlock)block
+- (void)synchronouslyLockFileAccessWhileExecutingBlock:(PIN_NOESCAPE PINCacheBlock)block
 {
     if (block) {
         [self lockForWriting];
@@ -1320,7 +1320,7 @@ static NSURL *_sharedTrashURL;
     [self unlock];
 }
 
-- (void)enumerateObjectsWithBlock:(PINDiskCacheFileURLEnumerationBlock)block
+- (void)enumerateObjectsWithBlock:(PIN_NOESCAPE PINDiskCacheFileURLEnumerationBlock)block
 {
     if (!block)
         return;

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -591,7 +591,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
     
 }
 
-- (void)enumerateObjectsWithBlock:(PINCacheObjectEnumerationBlock)block
+- (void)enumerateObjectsWithBlock:(PIN_NOESCAPE PINCacheObjectEnumerationBlock)block
 {
     if (!block)
         return;


### PR DESCRIPTION
- The warnings raised were related to the usage of the `PIN_NOESCAPE`
which must be specified in the interface and implementation when used.