### PR TITLE
WIP: Add PINPurgeableMemoryCache as an alternative to PINMemoryCache

### DIFF
--- a/PINCache.xcodeproj/project.pbxproj
+++ b/PINCache.xcodeproj/project.pbxproj
@@ -18,6 +18,11 @@
 		6928EED31E4160EE00B5D975 /* PINCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 6928EED21E4160EE00B5D975 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6928EED41E4160FE00B5D975 /* PINCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 6928EED21E4160EE00B5D975 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6928EED51E41610700B5D975 /* PINCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 6928EED21E4160EE00B5D975 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		810865FA22B189A1008C3AEF /* PINPurgeableMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 810865F822B189A1008C3AEF /* PINPurgeableMemoryCache.h */; };
+		810865FB22B189A1008C3AEF /* PINPurgeableMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 810865F922B189A1008C3AEF /* PINPurgeableMemoryCache.m */; };
+		8108660122B18A35008C3AEF /* PINMemoryCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 810865FF22B189C9008C3AEF /* PINMemoryCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8108660222B18A35008C3AEF /* PINMemoryCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 810865FF22B189C9008C3AEF /* PINMemoryCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		811D0E6622B18A860098F7BC /* PINMemoryCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 810865FF22B189C9008C3AEF /* PINMemoryCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C30EE1F520373D1900D78CB9 /* NSDate+PINCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C30EE1EA203717DE00D78CB9 /* NSDate+PINCacheTests.m */; };
 		C30EE1F620373D1A00D78CB9 /* NSDate+PINCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C30EE1EA203717DE00D78CB9 /* NSDate+PINCacheTests.m */; };
 		C30EE1F720373D1B00D78CB9 /* NSDate+PINCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C30EE1EA203717DE00D78CB9 /* NSDate+PINCacheTests.m */; };
@@ -177,6 +182,9 @@
 		6818C2901E564C1100875DB7 /* PINOperation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PINOperation.xcodeproj; path = Carthage/Checkouts/PINOperation/PINOperation.xcodeproj; sourceTree = "<group>"; };
 		68A0FBFF1E4D3282000B552D /* PINCacheMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheMacros.h; sourceTree = "<group>"; };
 		6928EED21E4160EE00B5D975 /* PINCaching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PINCaching.h; sourceTree = "<group>"; };
+		810865F822B189A1008C3AEF /* PINPurgeableMemoryCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINPurgeableMemoryCache.h; sourceTree = "<group>"; };
+		810865F922B189A1008C3AEF /* PINPurgeableMemoryCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINPurgeableMemoryCache.m; sourceTree = "<group>"; };
+		810865FF22B189C9008C3AEF /* PINMemoryCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINMemoryCaching.h; sourceTree = "<group>"; };
 		C30EE1E9203717DE00D78CB9 /* NSDate+PINCacheTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDate+PINCacheTests.h"; sourceTree = "<group>"; };
 		C30EE1EA203717DE00D78CB9 /* NSDate+PINCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDate+PINCacheTests.m"; sourceTree = "<group>"; };
 		C38F01A820A32E0200F47F0E /* PINDiskCache+PINCacheTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PINDiskCache+PINCacheTests.h"; sourceTree = "<group>"; };
@@ -310,8 +318,11 @@
 				CC0106071E271A9000890935 /* PINCacheObjectSubscripting.h */,
 				CC0106081E271A9000890935 /* PINDiskCache.h */,
 				CC0106091E271A9000890935 /* PINDiskCache.m */,
+				810865FF22B189C9008C3AEF /* PINMemoryCaching.h */,
 				CC01060A1E271A9000890935 /* PINMemoryCache.h */,
 				CC01060B1E271A9000890935 /* PINMemoryCache.m */,
+				810865F822B189A1008C3AEF /* PINPurgeableMemoryCache.h */,
+				810865F922B189A1008C3AEF /* PINPurgeableMemoryCache.m */,
 				68A0FBFF1E4D3282000B552D /* PINCacheMacros.h */,
 			);
 			path = Source;
@@ -349,8 +360,10 @@
 			files = (
 				6928EED31E4160EE00B5D975 /* PINCaching.h in Headers */,
 				CC0106171E271AAF00890935 /* PINCache.h in Headers */,
+				810865FA22B189A1008C3AEF /* PINPurgeableMemoryCache.h in Headers */,
 				68A0FC001E4D32C4000B552D /* PINCacheMacros.h in Headers */,
 				CC0106181E271AAF00890935 /* PINCacheObjectSubscripting.h in Headers */,
+				811D0E6622B18A860098F7BC /* PINMemoryCaching.h in Headers */,
 				CC01061A1E271AAF00890935 /* PINMemoryCache.h in Headers */,
 				C38F01AA20A32E0200F47F0E /* PINDiskCache+PINCacheTests.h in Headers */,
 				CC0106191E271AAF00890935 /* PINDiskCache.h in Headers */,
@@ -363,6 +376,7 @@
 			files = (
 				6928EED41E4160FE00B5D975 /* PINCaching.h in Headers */,
 				CC01061B1E271AB000890935 /* PINCache.h in Headers */,
+				8108660122B18A35008C3AEF /* PINMemoryCaching.h in Headers */,
 				68A0FC011E4D32C6000B552D /* PINCacheMacros.h in Headers */,
 				CC01061C1E271AB000890935 /* PINCacheObjectSubscripting.h in Headers */,
 				CC01061E1E271AB000890935 /* PINMemoryCache.h in Headers */,
@@ -376,6 +390,7 @@
 			files = (
 				6928EED51E41610700B5D975 /* PINCaching.h in Headers */,
 				CC01061F1E271AB000890935 /* PINCache.h in Headers */,
+				8108660222B18A35008C3AEF /* PINMemoryCaching.h in Headers */,
 				68A0FC021E4D32C7000B552D /* PINCacheMacros.h in Headers */,
 				CC0106201E271AB000890935 /* PINCacheObjectSubscripting.h in Headers */,
 				CC0106221E271AB000890935 /* PINMemoryCache.h in Headers */,
@@ -659,6 +674,7 @@
 				CC0106101E271A9500890935 /* PINMemoryCache.m in Sources */,
 				C38F01AB20A32E0200F47F0E /* PINDiskCache+PINCacheTests.m in Sources */,
 				CC01060F1E271A9500890935 /* PINDiskCache.m in Sources */,
+				810865FB22B189A1008C3AEF /* PINPurgeableMemoryCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -7,7 +7,7 @@
 #import <PINCache/PINCacheMacros.h>
 #import <PINCache/PINCaching.h>
 #import <PINCache/PINDiskCache.h>
-#import <PINCache/PINMemoryCache.h>
+#import <PINCache/PINMemoryCaching.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -50,7 +50,7 @@ PIN_SUBCLASSING_RESTRICTED
 /**
  The underlying memory cache, see <PINMemoryCache> for additional configuration and trimming options.
  */
-@property (readonly) PINMemoryCache *memoryCache;
+@property (readonly) id<PINMemoryCaching> memoryCache;
 
 #pragma mark - Lifecycle
 /// @name Initialization
@@ -147,7 +147,34 @@ PIN_SUBCLASSING_RESTRICTED
                 deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
                   keyEncoder:(nullable PINDiskCacheKeyEncoderBlock)keyEncoder
                   keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyDecoder
-                    ttlCache:(BOOL)ttlCache NS_DESIGNATED_INITIALIZER;
+                    ttlCache:(BOOL)ttlCache;
+
+
+/**
+ Multiple instances with the same name are *not* allowed and can *not* safely
+ access the same data on disk. Also used to create the <diskCache>.
+ Initializer allows you to override default NSKeyedArchiver/NSKeyedUnarchiver serialization for <diskCache>.
+ You must provide both serializer and deserializer, or opt-out to default implementation providing nil values.
+
+ @see name
+ @param name The name of the cache.
+ @param rootPath The path of the cache on disk.
+ @param serializer   A block used to serialize object before writing to disk. If nil provided, default NSKeyedArchiver serialized will be used.
+ @param deserializer A block used to deserialize object read from disk. If nil provided, default NSKeyedUnarchiver serialized will be used.
+ @param keyEncoder A block used to encode key(filename). If nil provided, default url encoder will be used
+ @param keyDecoder A block used to decode key(filename). If nil provided, default url decoder will be used
+ @param ttlCache Whether or not the cache should behave as a TTL cache.
+ @param purgeableMemoryCache If the underlying memory cache utilizes purgeable memory and can discard objects when under memory pressure. Default is `NO`
+ @result A new cache with the specified name.
+ */
+- (instancetype)initWithName:(nonnull NSString *)name
+                    rootPath:(nonnull NSString *)rootPath
+                  serializer:(nullable PINDiskCacheSerializerBlock)serializer
+                deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
+                  keyEncoder:(nullable PINDiskCacheKeyEncoderBlock)keyEncoder
+                  keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyDecoder
+                    ttlCache:(BOOL)ttlCache
+                    purgeableMemoryCache:(BOOL)purgeableMemoryCache NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Source/PINMemoryCache.h
+++ b/Source/PINMemoryCache.h
@@ -7,12 +7,11 @@
 #import <PINCache/PINCacheMacros.h>
 #import <PINCache/PINCaching.h>
 #import <PINCache/PINCacheObjectSubscripting.h>
-
+#import <PINCache/PINMemoryCaching.h>
 NS_ASSUME_NONNULL_BEGIN
 
 @class PINMemoryCache;
 @class PINOperationQueue;
-
 
 /**
  `PINMemoryCache` is a fast, thread safe key/value store similar to `NSCache`. On iOS it will clear itself
@@ -32,116 +31,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 
 PIN_SUBCLASSING_RESTRICTED
-@interface PINMemoryCache : NSObject <PINCaching, PINCacheObjectSubscripting>
-
-#pragma mark - Properties
-/// @name Core
-
-/**
- The total accumulated cost.
- */
-@property (readonly) NSUInteger totalCost;
-
-/**
- The maximum cost allowed to accumulate before objects begin to be removed with <trimToCostByDate:>.
- */
-@property (assign) NSUInteger costLimit;
-
-/**
- The maximum number of seconds an object is allowed to exist in the cache. Setting this to a value
- greater than `0.0` will start a recurring GCD timer with the same period that calls <trimToDate:>.
- Setting it back to `0.0` will stop the timer. Defaults to `0.0`.
- */
-@property (assign) NSTimeInterval ageLimit;
-
-/**
- If ttlCache is YES, the cache behaves like a ttlCache. This means that once an object enters the
- cache, it only lives as long as self.ageLimit. This has the following implications:
- - Accessing an object in the cache does not extend that object's lifetime in the cache
- - When attempting to access an object in the cache that has lived longer than self.ageLimit,
- the cache will behave as if the object does not exist
- 
- @note If an object-level age limit is set via one of the @c -setObject:forKey:withAgeLimit methods,
-       that age limit overrides self.ageLimit. The overridden object age limit could be greater or
-       less than self.agelimit but must be greater than zero.
- */
-@property (nonatomic, readonly, getter=isTTLCache) BOOL ttlCache;
-
-/**
- When `YES` on iOS the cache will remove all objects when the app receives a memory warning.
- Defaults to `YES`.
- */
-@property (assign) BOOL removeAllObjectsOnMemoryWarning;
-
-/**
- When `YES` on iOS the cache will remove all objects when the app enters the background.
- Defaults to `YES`.
- */
-@property (assign) BOOL removeAllObjectsOnEnteringBackground;
-
-#pragma mark - Event Blocks
-/// @name Event Blocks
-
-/**
- A block to be executed just before an object is added to the cache. This block will be excuted within
- a lock, i.e. all reads and writes are suspended for the duration of the block.
- Calling synchronous methods on the cache within this callback will likely cause a deadlock.
- */
-@property (nullable, copy) PINCacheObjectBlock willAddObjectBlock;
-
-/**
- A block to be executed just before an object is removed from the cache. This block will be excuted
- within a lock, i.e. all reads and writes are suspended for the duration of the block.
- Calling synchronous methods on the cache within this callback will likely cause a deadlock.
- */
-@property (nullable, copy) PINCacheObjectBlock willRemoveObjectBlock;
-
-/**
- A block to be executed just before all objects are removed from the cache as a result of <removeAllObjects:>.
- This block will be excuted within a lock, i.e. all reads and writes are suspended for the duration of the block.
- Calling synchronous methods on the cache within this callback will likely cause a deadlock.
- */
-@property (nullable, copy) PINCacheBlock willRemoveAllObjectsBlock;
-
-/**
- A block to be executed just after an object is added to the cache. This block will be excuted within
- a lock, i.e. all reads and writes are suspended for the duration of the block.
- Calling synchronous methods on the cache within this callback will likely cause a deadlock.
- */
-@property (nullable, copy) PINCacheObjectBlock didAddObjectBlock;
-
-/**
- A block to be executed just after an object is removed from the cache. This block will be excuted
- within a lock, i.e. all reads and writes are suspended for the duration of the block.
- Calling synchronous methods on the cache within this callback will likely cause a deadlock.
- */
-@property (nullable, copy) PINCacheObjectBlock didRemoveObjectBlock;
-
-/**
- A block to be executed just after all objects are removed from the cache as a result of <removeAllObjects:>.
- This block will be excuted within a lock, i.e. all reads and writes are suspended for the duration of the block.
- Calling synchronous methods on the cache within this callback will likely cause a deadlock.
- */
-@property (nullable, copy) PINCacheBlock didRemoveAllObjectsBlock;
-
-/**
- A block to be executed upon receiving a memory warning (iOS only) potentially in parallel with other blocks on the <queue>.
- This block will be executed regardless of the value of <removeAllObjectsOnMemoryWarning>. Defaults to `nil`.
- */
-@property (nullable, copy) PINCacheBlock didReceiveMemoryWarningBlock;
-
-/**
- A block to be executed when the app enters the background (iOS only) potentially in parallel with other blocks on the <concurrentQueue>.
- This block will be executed regardless of the value of <removeAllObjectsOnEnteringBackground>. Defaults to `nil`.
- */
-@property (nullable, copy) PINCacheBlock didEnterBackgroundBlock;
+@interface PINMemoryCache : NSObject <PINMemoryCaching>
 
 #pragma mark - Lifecycle
 /// @name Shared Cache
 
 /**
  A shared cache.
- 
+
  @result The shared singleton cache instance.
  */
 @property (class, strong, readonly) PINMemoryCache *sharedCache;
@@ -151,73 +48,6 @@ PIN_SUBCLASSING_RESTRICTED
 - (instancetype)initWithName:(NSString *)name operationQueue:(PINOperationQueue *)operationQueue;
 
 - (instancetype)initWithName:(NSString *)name operationQueue:(PINOperationQueue *)operationQueue ttlCache:(BOOL)ttlCache NS_DESIGNATED_INITIALIZER;
-
-#pragma mark - Asynchronous Methods
-/// @name Asynchronous Methods
-
-/**
- Removes objects from the cache, costliest objects first, until the <totalCost> is below the specified
- value. This method returns immediately and executes the passed block after the cache has been trimmed,
- potentially in parallel with other blocks on the <concurrentQueue>.
- 
- @param cost The total accumulation allowed to remain after the cache has been trimmed.
- @param block A block to be executed concurrently after the cache has been trimmed, or nil.
- */
-- (void)trimToCostAsync:(NSUInteger)cost completion:(nullable PINCacheBlock)block;
-
-/**
- Removes objects from the cache, ordered by date (least recently used first), until the <totalCost> is below
- the specified value. This method returns immediately and executes the passed block after the cache has been
- trimmed, potentially in parallel with other blocks on the <concurrentQueue>.
- 
- @param cost The total accumulation allowed to remain after the cache has been trimmed.
- @param block A block to be executed concurrently after the cache has been trimmed, or nil.
- */
-- (void)trimToCostByDateAsync:(NSUInteger)cost completion:(nullable PINCacheBlock)block;
-
-/**
- Loops through all objects in the cache with reads and writes suspended. Calling serial methods which
- write to the cache inside block may be unsafe and may result in a deadlock. This method returns immediately.
- 
- @param block A block to be executed for every object in the cache.
- @param completionBlock An optional block to be executed concurrently when the enumeration is complete.
- */
-- (void)enumerateObjectsWithBlockAsync:(PINCacheObjectEnumerationBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
-
-#pragma mark - Synchronous Methods
-/// @name Synchronous Methods
-
-/**
- Removes objects from the cache, costliest objects first, until the <totalCost> is below the specified
- value. This method blocks the calling thread until the cache has been trimmed.
- 
- @see trimToCostAsync:
- @param cost The total accumulation allowed to remain after the cache has been trimmed.
- */
-- (void)trimToCost:(NSUInteger)cost;
-
-/**
- Removes objects from the cache, ordered by date (least recently used first), until the <totalCost> is below
- the specified value. This method blocks the calling thread until the cache has been trimmed.
- 
- @see trimToCostByDateAsync:
- @param cost The total accumulation allowed to remain after the cache has been trimmed.
- */
-- (void)trimToCostByDate:(NSUInteger)cost;
-
-/**
- Loops through all objects in the cache within a memory lock (reads and writes are suspended during the enumeration).
- This method blocks the calling thread until all objects have been enumerated.
- Calling synchronous methods on the cache within this callback will likely cause a deadlock.
- 
- @see enumerateObjectsWithBlockAsync:completionBlock:
- @param block A block to be executed for every object in the cache.
- 
- @warning Do not call this method within the event blocks (<didReceiveMemoryWarningBlock>, etc.)
- Instead use the asynchronous version, <enumerateObjectsWithBlock:completionBlock:>.
- 
- */
-- (void)enumerateObjectsWithBlock:(PIN_NOESCAPE PINCacheObjectEnumerationBlock)block;
 
 @end
 

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -40,6 +40,9 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 @synthesize didRemoveAllObjectsBlock = _didRemoveAllObjectsBlock;
 @synthesize didReceiveMemoryWarningBlock = _didReceiveMemoryWarningBlock;
 @synthesize didEnterBackgroundBlock = _didEnterBackgroundBlock;
+@synthesize removeAllObjectsOnMemoryWarning = _removeAllObjectsOnMemoryWarning;
+@synthesize removeAllObjectsOnEnteringBackground = _removeAllObjectsOnEnteringBackground;
+
 
 #pragma mark - Initialization -
 

--- a/Source/PINMemoryCaching.h
+++ b/Source/PINMemoryCaching.h
@@ -1,0 +1,194 @@
+//
+//  PINMemoryCaching.m
+//  PINCache
+//
+//  Created by Rahul Malik on 6/12/19.
+//  Copyright © 2019 Pinterest. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import <PINCache/PINCacheMacros.h>
+#import <PINCache/PINCaching.h>
+#import <PINCache/PINCacheObjectSubscripting.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol PINMemoryCaching <PINCaching, PINCacheObjectSubscripting>
+
+
+#pragma mark - Properties
+/// @name Core
+
+/**
+ The total accumulated cost.
+ */
+@property (readonly) NSUInteger totalCost;
+
+/**
+ The maximum cost allowed to accumulate before objects begin to be removed with <trimToCostByDate:>.
+ */
+@property (assign) NSUInteger costLimit;
+
+/**
+ The maximum number of seconds an object is allowed to exist in the cache. Setting this to a value
+ greater than `0.0` will start a recurring GCD timer with the same period that calls <trimToDate:>.
+ Setting it back to `0.0` will stop the timer. Defaults to `0.0`.
+ */
+@property (assign) NSTimeInterval ageLimit;
+
+/**
+ If ttlCache is YES, the cache behaves like a ttlCache. This means that once an object enters the
+ cache, it only lives as long as self.ageLimit. This has the following implications:
+ - Accessing an object in the cache does not extend that object's lifetime in the cache
+ - When attempting to access an object in the cache that has lived longer than self.ageLimit,
+ the cache will behave as if the object does not exist
+
+ @note If an object-level age limit is set via one of the @c -setObject:forKey:withAgeLimit methods,
+ that age limit overrides self.ageLimit. The overridden object age limit could be greater or
+ less than self.agelimit but must be greater than zero.
+ */
+@property (nonatomic, readonly, getter=isTTLCache) BOOL ttlCache;
+
+/**
+ When `YES` on iOS the cache will remove all objects when the app receives a memory warning.
+ Defaults to `YES`.
+ */
+@property (assign) BOOL removeAllObjectsOnMemoryWarning;
+
+/**
+ When `YES` on iOS the cache will remove all objects when the app enters the background.
+ Defaults to `YES`.
+ */
+@property (assign) BOOL removeAllObjectsOnEnteringBackground;
+
+#pragma mark - Event Blocks
+/// @name Event Blocks
+
+/**
+ A block to be executed just before an object is added to the cache. This block will be excuted within
+ a lock, i.e. all reads and writes are suspended for the duration of the block.
+ Calling synchronous methods on the cache within this callback will likely cause a deadlock.
+ */
+@property (nullable, copy) PINCacheObjectBlock willAddObjectBlock;
+
+/**
+ A block to be executed just before an object is removed from the cache. This block will be excuted
+ within a lock, i.e. all reads and writes are suspended for the duration of the block.
+ Calling synchronous methods on the cache within this callback will likely cause a deadlock.
+ */
+@property (nullable, copy) PINCacheObjectBlock willRemoveObjectBlock;
+
+/**
+ A block to be executed just before all objects are removed from the cache as a result of <removeAllObjects:>.
+ This block will be excuted within a lock, i.e. all reads and writes are suspended for the duration of the block.
+ Calling synchronous methods on the cache within this callback will likely cause a deadlock.
+ */
+@property (nullable, copy) PINCacheBlock willRemoveAllObjectsBlock;
+
+/**
+ A block to be executed just after an object is added to the cache. This block will be excuted within
+ a lock, i.e. all reads and writes are suspended for the duration of the block.
+ Calling synchronous methods on the cache within this callback will likely cause a deadlock.
+ */
+@property (nullable, copy) PINCacheObjectBlock didAddObjectBlock;
+
+/**
+ A block to be executed just after an object is removed from the cache. This block will be excuted
+ within a lock, i.e. all reads and writes are suspended for the duration of the block.
+ Calling synchronous methods on the cache within this callback will likely cause a deadlock.
+ */
+@property (nullable, copy) PINCacheObjectBlock didRemoveObjectBlock;
+
+/**
+ A block to be executed just after all objects are removed from the cache as a result of <removeAllObjects:>.
+ This block will be excuted within a lock, i.e. all reads and writes are suspended for the duration of the block.
+ Calling synchronous methods on the cache within this callback will likely cause a deadlock.
+ */
+@property (nullable, copy) PINCacheBlock didRemoveAllObjectsBlock;
+
+/**
+ A block to be executed upon receiving a memory warning (iOS only) potentially in parallel with other blocks on the <queue>.
+ This block will be executed regardless of the value of <removeAllObjectsOnMemoryWarning>. Defaults to `nil`.
+ */
+@property (nullable, copy) PINCacheBlock didReceiveMemoryWarningBlock;
+
+/**
+ A block to be executed when the app enters the background (iOS only) potentially in parallel with other blocks on the <concurrentQueue>.
+ This block will be executed regardless of the value of <removeAllObjectsOnEnteringBackground>. Defaults to `nil`.
+ */
+@property (nullable, copy) PINCacheBlock didEnterBackgroundBlock;
+
+#pragma mark - Asynchronous Methods
+/// @name Asynchronous Methods
+
+/**
+ Removes objects from the cache, costliest objects first, until the <totalCost> is below the specified
+ value. This method returns immediately and executes the passed block after the cache has been trimmed,
+ potentially in parallel with other blocks on the <concurrentQueue>.
+
+ @param cost The total accumulation allowed to remain after the cache has been trimmed.
+ @param block A block to be executed concurrently after the cache has been trimmed, or nil.
+ */
+- (void)trimToCostAsync:(NSUInteger)cost completion:(nullable PINCacheBlock)block;
+
+/**
+ Removes objects from the cache, ordered by date (least recently used first), until the <totalCost> is below
+ the specified value. This method returns immediately and executes the passed block after the cache has been
+ trimmed, potentially in parallel with other blocks on the <concurrentQueue>.
+
+ @param cost The total accumulation allowed to remain after the cache has been trimmed.
+ @param block A block to be executed concurrently after the cache has been trimmed, or nil.
+ */
+- (void)trimToCostByDateAsync:(NSUInteger)cost completion:(nullable PINCacheBlock)block;
+
+/**
+ Loops through all objects in the cache with reads and writes suspended. Calling serial methods which
+ write to the cache inside block may be unsafe and may result in a deadlock. This method returns immediately.
+
+ @param block A block to be executed for every object in the cache.
+ @param completionBlock An optional block to be executed concurrently when the enumeration is complete.
+ */
+- (void)enumerateObjectsWithBlockAsync:(PINCacheObjectEnumerationBlock)block completionBlock:(nullable PINCacheBlock)completionBlock;
+
+#pragma mark - Synchronous Methods
+/// @name Synchronous Methods
+
+/**
+ Removes objects from the cache, costliest objects first, until the <totalCost> is below the specified
+ value. This method blocks the calling thread until the cache has been trimmed.
+
+ @see trimToCostAsync:
+ @param cost The total accumulation allowed to remain after the cache has been trimmed.
+ */
+- (void)trimToCost:(NSUInteger)cost;
+
+/**
+ Removes objects from the cache, ordered by date (least recently used first), until the <totalCost> is below
+ the specified value. This method blocks the calling thread until the cache has been trimmed.
+
+ @see trimToCostByDateAsync:
+ @param cost The total accumulation allowed to remain after the cache has been trimmed.
+ */
+- (void)trimToCostByDate:(NSUInteger)cost;
+
+/**
+ Loops through all objects in the cache within a memory lock (reads and writes are suspended during the enumeration).
+ This method blocks the calling thread until all objects have been enumerated.
+ Calling synchronous methods on the cache within this callback will likely cause a deadlock.
+
+ @see enumerateObjectsWithBlockAsync:completionBlock:
+ @param block A block to be executed for every object in the cache.
+
+ @warning Do not call this method within the event blocks (<didReceiveMemoryWarningBlock>, etc.)
+ Instead use the asynchronous version, <enumerateObjectsWithBlock:completionBlock:>.
+
+ */
+- (void)enumerateObjectsWithBlock:(PIN_NOESCAPE PINCacheObjectEnumerationBlock)block;
+
+- (void)setTtlCache:(BOOL)ttlCache DEPRECATED_MSG_ATTRIBUTE("ttlCache is no longer a settable property and must now be set via initializer.");
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PINPurgeableMemoryCache.h
+++ b/Source/PINPurgeableMemoryCache.h
@@ -1,0 +1,22 @@
+//
+//  PINPurgeableMemoryCache.h
+//  PINCache
+//
+//  Created by Rahul Malik on 6/12/19.
+//  Copyright © 2019 Pinterest. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import <PINCache/PINMemoryCaching.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class PINOperationQueue;
+
+@interface PINPurgeableMemoryCache : NSObject<PINMemoryCaching>
+- (instancetype)initWithOperationQueue:(PINOperationQueue *)operationQueue;
+- (instancetype)initWithName:(NSString *)name operationQueue:(PINOperationQueue *)operationQueue;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PINPurgeableMemoryCache.m
+++ b/Source/PINPurgeableMemoryCache.m
@@ -1,0 +1,225 @@
+//
+//  PINPurgeableMemoryCache.m
+//  PINCache
+//
+//  Created by Rahul Malik on 6/12/19.
+//  Copyright © 2019 Pinterest. All rights reserved.
+//
+
+#import "PINPurgeableMemoryCache.h"
+#import <PINOperation/PINOperation.h>
+
+static NSString * const PINPurgeableMemoryCacheSharedName = @"PINPurgeableMemoryCacheSharedName";
+
+
+@implementation PINPurgeableMemoryCache
+{
+    NSString *_name;
+    NSCache *_internalCache;
+    PINOperationQueue *_operationQueue;
+}
+
+@synthesize name = _name;
+@synthesize ageLimit = _ageLimit;
+@synthesize costLimit = _costLimit;
+@synthesize totalCost = _totalCost;
+@synthesize ttlCache = _ttlCache;
+@synthesize willAddObjectBlock = _willAddObjectBlock;
+@synthesize willRemoveObjectBlock = _willRemoveObjectBlock;
+@synthesize willRemoveAllObjectsBlock = _willRemoveAllObjectsBlock;
+@synthesize didAddObjectBlock = _didAddObjectBlock;
+@synthesize didRemoveObjectBlock = _didRemoveObjectBlock;
+@synthesize didRemoveAllObjectsBlock = _didRemoveAllObjectsBlock;
+@synthesize didReceiveMemoryWarningBlock = _didReceiveMemoryWarningBlock;
+@synthesize didEnterBackgroundBlock = _didEnterBackgroundBlock;
+@synthesize removeAllObjectsOnMemoryWarning = _removeAllObjectsOnMemoryWarning;
+@synthesize removeAllObjectsOnEnteringBackground = _removeAllObjectsOnEnteringBackground;
+
+
+- (instancetype)init
+{
+    return [self initWithOperationQueue:[PINOperationQueue sharedOperationQueue]];
+}
+
+- (instancetype)initWithOperationQueue:(PINOperationQueue *)operationQueue
+{
+    return [self initWithName:PINPurgeableMemoryCacheSharedName
+               operationQueue:operationQueue];
+}
+
+
+- (instancetype)initWithName:(NSString *)name operationQueue:(PINOperationQueue *)operationQueue
+{
+    if (self = [super init]) {
+        _name = [name copy];
+        _operationQueue = operationQueue;
+        _internalCache = [[NSCache alloc] init];
+        _willAddObjectBlock = nil;
+        _willRemoveObjectBlock = nil;
+        _willRemoveAllObjectsBlock = nil;
+        _didAddObjectBlock = nil;
+        _didRemoveObjectBlock = nil;
+        _didRemoveAllObjectsBlock = nil;
+        _didReceiveMemoryWarningBlock = nil;
+        _didEnterBackgroundBlock = nil;
+//        _removeAllObjectsOnMemoryWarning = YES;
+//        _removeAllObjectsOnEnteringBackground = YES;
+
+//#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !TARGET_OS_WATCH
+//        [[NSNotificationCenter defaultCenter] addObserver:self
+//                                                 selector:@selector(didReceiveEnterBackgroundNotification:)
+//                                                     name:UIApplicationDidEnterBackgroundNotification
+//                                                   object:nil];
+//        [[NSNotificationCenter defaultCenter] addObserver:self
+//                                                 selector:@selector(didReceiveMemoryWarningNotification:)
+//                                                     name:UIApplicationDidReceiveMemoryWarningNotification
+//                                                   object:nil];
+//
+//#endif
+    }
+    return self;
+}
+
+
+- (BOOL)containsObjectForKey:(nonnull NSString *)key {
+    return [_internalCache objectForKey:key];
+}
+
+- (void)containsObjectForKeyAsync:(nonnull NSString *)key completion:(nonnull PINCacheObjectContainmentBlock)block {
+    [_operationQueue scheduleOperation:^{
+        return block([self->_internalCache objectForKey:key] != nil);
+    }];
+}
+
+- (nullable id)objectForKey:(nonnull NSString *)key {
+    return [_internalCache objectForKey:key];
+}
+
+- (void)objectForKeyAsync:(nonnull NSString *)key completion:(nonnull PINCacheObjectBlock)block {
+    [_operationQueue scheduleOperation:^{
+        block(self, key, [self->_internalCache objectForKey:key]);
+    }];
+}
+
+- (void)removeAllObjects {
+    [_internalCache removeAllObjects];
+}
+
+- (void)removeAllObjectsAsync:(nullable PINCacheBlock)block {
+    [_operationQueue scheduleOperation:^{
+        [self->_internalCache removeAllObjects];
+    }];
+}
+
+- (void)removeExpiredObjects {
+    // NO-OP
+}
+
+- (void)removeExpiredObjectsAsync:(nullable PINCacheBlock)block {
+    // NO-OP
+
+}
+
+- (void)removeObjectForKey:(nonnull NSString *)key {
+    [_internalCache removeObjectForKey:key];
+}
+
+- (void)removeObjectForKeyAsync:(nonnull NSString *)key completion:(nullable PINCacheObjectBlock)block {
+    [_operationQueue scheduleOperation:^{
+        [self->_internalCache removeObjectForKey:key];
+    }];
+}
+
+- (void)setObject:(nullable id)object forKey:(nonnull NSString *)key {
+    [_internalCache setObject:object forKey:key];
+}
+
+- (void)setObject:(nullable id)object forKey:(nonnull NSString *)key withAgeLimit:(NSTimeInterval)ageLimit {
+    // Same as setObject:forKey:
+    // Look into removing this API
+    [self setObject:object forKey:key];
+}
+
+- (void)setObject:(nullable id)object forKey:(nonnull NSString *)key withCost:(NSUInteger)cost {
+    [_internalCache setObject:object forKey:key cost:cost];
+}
+
+- (void)setObject:(nullable id)object forKey:(nonnull NSString *)key withCost:(NSUInteger)cost ageLimit:(NSTimeInterval)ageLimit {
+    // Same as setObject:forKey:cost:
+    // Look into removing this API
+    [self setObject:object forKey:key withCost:cost];
+}
+
+- (void)setObjectAsync:(nonnull id)object forKey:(nonnull NSString *)key completion:(nullable PINCacheObjectBlock)block {
+    [_operationQueue scheduleOperation:^{
+        [self->_internalCache setObject:object forKey:key];
+        if (block) {
+            block(self, key, object);
+        }
+
+    }];
+}
+
+- (void)setObjectAsync:(nonnull id)object forKey:(nonnull NSString *)key withAgeLimit:(NSTimeInterval)ageLimit completion:(nullable PINCacheObjectBlock)block {
+    [self setObjectAsync:object forKey:key completion:block];
+}
+
+- (void)setObjectAsync:(nonnull id)object forKey:(nonnull NSString *)key withCost:(NSUInteger)cost ageLimit:(NSTimeInterval)ageLimit completion:(nullable PINCacheObjectBlock)block {
+    [self setObjectAsync:object forKey:key withCost:cost  completion:block];
+}
+
+- (void)setObjectAsync:(nonnull id)object forKey:(nonnull NSString *)key withCost:(NSUInteger)cost completion:(nullable PINCacheObjectBlock)block {
+    [_operationQueue scheduleOperation:^{
+        [self->_internalCache setObject:object forKey:key cost:cost];
+    }];
+}
+
+- (void)trimToDate:(nonnull NSDate *)date {
+    // NO-OP
+}
+
+- (void)trimToDateAsync:(nonnull NSDate *)date completion:(nullable PINCacheBlock)block {
+    // NO-OP
+    block(self);
+}
+
+- (void)enumerateObjectsWithBlock:(PIN_NOESCAPE PINCacheObjectEnumerationBlock)block {
+    // NO-OP - Should we assert here?
+}
+
+- (void)enumerateObjectsWithBlockAsync:(PINCacheObjectEnumerationBlock)block completionBlock:(nullable PINCacheBlock)completionBlock {
+    // NO-OP
+    completionBlock(self);
+}
+
+- (void)trimToCost:(NSUInteger)cost {
+    // NO-OP (nscache handles this internally)
+}
+
+- (void)trimToCostAsync:(NSUInteger)cost completion:(nullable PINCacheBlock)block {
+    // NO-OP (nscache handles this internally)
+    block(self);
+}
+
+- (void)trimToCostByDate:(NSUInteger)cost {
+    // NO-OP (nscache handles this internally)
+}
+
+- (void)trimToCostByDateAsync:(NSUInteger)cost completion:(nullable PINCacheBlock)block {
+    // NO-OP (nscache handles this internally)
+    block(self);
+}
+
+#pragma mark PINCacheObjectSubscripting
+
+- (nullable id)objectForKeyedSubscript:(NSString *)key
+{
+    return [self objectForKey:key];
+}
+
+- (void)setObject:(nullable id)object forKeyedSubscript:(NSString *)key
+{
+    [self setObject:object forKey:key];
+}
+
+@end

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -7,7 +7,7 @@
 #import "PINDiskCache+PINCacheTests.h"
 #import <PINCache/PINCache.h>
 #import <PINOperation/PINOperation.h>
-
+#import <PINCache/PINMemoryCache.h>
 
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
   typedef UIImage PINImage;
@@ -39,6 +39,8 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 @interface PINCacheTests ()
 @property (strong, nonatomic) PINCache *cache;
 @end
+
+
 
 @implementation PINCacheTests
 


### PR DESCRIPTION
- Key difference is utilizing NSCache internally to allow the system to
purge memory if needed
- Locking is not managed by PINPurgeableMemoryCache as NSCache is designed to be thread-safe

TODO:
- Decide how to handle TTL, Age limit, etc requirements
- Add tests to ensure it works similar to PINMemoryCache (within reason)
- Ideally benchmark performance of memory cache with this change