### PR TITLE
Clean code with `PINCache` requires environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## master
 
 * Add your own contributions to the next release on the line below this with your name.
+- [performance] Clean code with `PINCache` requires environment . [#250](https://github.com/pinterest/PINCache/pull/250)
+
 
 ## 3.0.1 -- Beta 8
 - [fix] Initing PINCache with TTL enabled should enable TTL on PINMemoryCache. [#246](https://github.com/pinterest/PINCache/pull/246)

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -7,7 +7,7 @@
 #import <pthread.h>
 #import <PINOperation/PINOperation.h>
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED 
 #import <UIKit/UIKit.h>
 #endif
 
@@ -100,7 +100,7 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
         _removeAllObjectsOnMemoryWarning = YES;
         _removeAllObjectsOnEnteringBackground = YES;
         
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !TARGET_OS_WATCH
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(didReceiveEnterBackgroundNotification:)
                                                      name:UIApplicationDidEnterBackgroundNotification


### PR DESCRIPTION
With PINCache requires:
```ruby
  s.ios.deployment_target = '8.0'
  s.osx.deployment_target = '10.11'
  s.tvos.deployment_target = '9.0'
  s.watchos.deployment_target = '2.0'
```
So we can clean unused code.
