### PR TITLE
Optimize `PINMemoryCache` remove objects when receive memory warning notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add your own contributions to the next release on the line below this with your name.
 
+- [performance] Optimize `PINMemoryCache` remove objects when receive memory warning notification. [#251](https://github.com/pinterest/PINCache/pull/251)
+
 ## 3.0.1 -- Beta 8
 - [fix] Initing PINCache with TTL enabled should enable TTL on PINMemoryCache. [#246](https://github.com/pinterest/PINCache/pull/246)
 - [performance] Return TTL cache objects without waiting for all metadata to be read. [#228](https://github.com/pinterest/PINCache/pull/228)

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -130,10 +130,11 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 #pragma mark - Private Methods -
 
 - (void)didReceiveMemoryWarningNotification:(NSNotification *)notification {
-    if (self.removeAllObjectsOnMemoryWarning)
+    if (self.removeAllObjectsOnMemoryWarning) {
         [self removeAllObjectsAsync:nil];
-
-    [self removeExpiredObjects];
+    } else {
+        [self removeExpiredObjects];
+    }
 
     [self.operationQueue scheduleOperation:^{
         [self lock];


### PR DESCRIPTION
If you want remove all objects, there is pointless to remove expired objects