### PR TITLE
Check fileURL outside of the locked scope

### DIFF
--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -666,10 +666,13 @@ static NSURL *_sharedTrashURL;
 - (BOOL)removeFileAndExecuteBlocksForKey:(NSString *)key
 {
     NSURL *fileURL = [self encodedFileURLForKey:key];
-    
+    if (!fileURL) {
+        return NO;
+    }
+
     // We only need to lock until writable at the top because once writable, always writable
     [self lockForWriting];
-        if (!fileURL || ![[NSFileManager defaultManager] fileExistsAtPath:[fileURL path]]) {
+        if (![[NSFileManager defaultManager] fileExistsAtPath:[fileURL path]]) {
             [self unlock];
             return NO;
         }


### PR DESCRIPTION
We can exit immediately when fileURL is invalid without acquiring and
then releasing the write lock.