### PR TITLE
Fix compiling in Xcode 12.0b4

### DIFF
--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -118,7 +118,7 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
         return;
     
     [self.operationQueue scheduleOperation:^{
-        [self->_memoryCache objectForKeyAsync:key completion:^(PINMemoryCache *memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
+        [self->_memoryCache objectForKeyAsync:key completion:^(id<PINCaching> memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
             if (memoryCacheObject) {
                 // Update file modification date. TODO: make this a separate method?
                 [self->_diskCache fileURLForKeyAsync:memoryCacheKey completion:^(NSString * _Nonnull key, NSURL * _Nullable fileURL) {}];
@@ -271,8 +271,8 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
 {
     __block NSUInteger byteCount = 0;
     
-    [_diskCache synchronouslyLockFileAccessWhileExecutingBlock:^(PINDiskCache *diskCache) {
-        byteCount = diskCache.byteCount;
+    [_diskCache synchronouslyLockFileAccessWhileExecutingBlock:^(id<PINCaching> diskCache) {
+        byteCount = ((PINDiskCache *)diskCache).byteCount;
     }];
     
     return byteCount;

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -677,7 +677,7 @@ static NSURL *_sharedTrashURL;
             return NO;
         }
     
-        PINCacheObjectBlock willRemoveObjectBlock = _willRemoveObjectBlock;
+        PINDiskCacheObjectBlock willRemoveObjectBlock = _willRemoveObjectBlock;
         if (willRemoveObjectBlock) {
             [self unlock];
             willRemoveObjectBlock(self, key, nil);
@@ -698,7 +698,7 @@ static NSURL *_sharedTrashURL;
         
         [_metadata removeObjectForKey:key];
     
-        PINCacheObjectBlock didRemoveObjectBlock = _didRemoveObjectBlock;
+        PINDiskCacheObjectBlock didRemoveObjectBlock = _didRemoveObjectBlock;
         if (didRemoveObjectBlock) {
             [self unlock];
             _didRemoveObjectBlock(self, key, nil);
@@ -1207,7 +1207,7 @@ static NSURL *_sharedTrashURL;
     }
 
     [self lockForWriting];
-        PINCacheObjectBlock willAddObjectBlock = self->_willAddObjectBlock;
+        PINDiskCacheObjectBlock willAddObjectBlock = self->_willAddObjectBlock;
         if (willAddObjectBlock) {
             [self unlock];
                 willAddObjectBlock(self, key, object);
@@ -1251,7 +1251,7 @@ static NSURL *_sharedTrashURL;
             fileURL = nil;
         }
     
-        PINCacheObjectBlock didAddObjectBlock = self->_didAddObjectBlock;
+        PINDiskCacheObjectBlock didAddObjectBlock = self->_didAddObjectBlock;
         if (didAddObjectBlock) {
             [self unlock];
                 didAddObjectBlock(self, key, object);
@@ -1663,29 +1663,49 @@ static NSURL *_sharedTrashURL;
 
 - (void)trimToDate:(NSDate *)date block:(nullable PINDiskCacheBlock)block
 {
-    [self trimToDateAsync:date completion:block];
+    [self trimToDateAsync:date completion:^(id<PINCaching> diskCache) {
+        if (block) {
+            block((PINDiskCache *)diskCache);
+        }
+    }];
 }
 
 - (void)trimToSize:(NSUInteger)byteCount block:(nullable PINDiskCacheBlock)block
 {
-    [self trimToSizeAsync:byteCount completion:block];
+    [self trimToSizeAsync:byteCount completion:^(id<PINCaching> diskCache) {
+        if (block) {
+            block((PINDiskCache *)diskCache);
+        }
+    }];
 }
 
 - (void)trimToSizeByDate:(NSUInteger)byteCount block:(nullable PINDiskCacheBlock)block
 {
-    [self trimToSizeAsync:byteCount completion:block];
+    [self trimToSizeAsync:byteCount completion:^(id<PINCaching> diskCache) {
+        if (block) {
+            block((PINDiskCache *)diskCache);
+        }
+    }];
 }
 
 - (void)removeAllObjects:(nullable PINDiskCacheBlock)block
 {
-    [self removeAllObjectsAsync:block];
+    [self removeAllObjectsAsync:^(id<PINCaching> diskCache) {
+        if (block) {
+            block((PINDiskCache *)diskCache);
+        }
+    }];
 }
 
 - (void)enumerateObjectsWithBlock:(PINDiskCacheFileURLBlock)block completionBlock:(nullable PINDiskCacheBlock)completionBlock
 {
     [self enumerateObjectsWithBlockAsync:^(NSString * _Nonnull key, NSURL * _Nullable fileURL, BOOL * _Nonnull stop) {
       block(key, fileURL);
-    } completionBlock:completionBlock];
+    } completionBlock:^(id<PINCaching> diskCache) {
+        if (completionBlock) {
+            completionBlock((PINDiskCache *)diskCache);
+        }
+    }];
 }
 
 - (void)setTtlCache:(BOOL)ttlCache

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -833,42 +833,74 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
 
 - (void)objectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block
 {
-    [self objectForKeyAsync:key completion:block];
+    [self objectForKeyAsync:key completion:^(id<PINCaching> memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
+        if (block) {
+            block((PINMemoryCache *)memoryCache, memoryCacheKey, memoryCacheObject);
+        }
+    }];
 }
 
 - (void)setObject:(id)object forKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block
 {
-    [self setObjectAsync:object forKey:key completion:block];
+    [self setObjectAsync:object forKey:key completion:^(id<PINCaching> memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
+        if (block) {
+            block((PINMemoryCache *)memoryCache, memoryCacheKey, memoryCacheObject);
+        }
+    }];
 }
 
 - (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(nullable PINMemoryCacheObjectBlock)block
 {
-    [self setObjectAsync:object forKey:key withCost:cost completion:block];
+    [self setObjectAsync:object forKey:key withCost:cost completion:^(id<PINCaching> memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
+        if (block) {
+            block((PINMemoryCache *)memoryCache, memoryCacheKey, memoryCacheObject);
+        }
+    }];
 }
 
 - (void)removeObjectForKey:(NSString *)key block:(nullable PINMemoryCacheObjectBlock)block
 {
-    [self removeObjectForKeyAsync:key completion:block];
+    [self removeObjectForKeyAsync:key completion:^(id<PINCaching> memoryCache, NSString *memoryCacheKey, id memoryCacheObject) {
+        if (block) {
+            block((PINMemoryCache *)memoryCache, memoryCacheKey, memoryCacheObject);
+        }
+    }];
 }
 
 - (void)trimToDate:(NSDate *)date block:(nullable PINMemoryCacheBlock)block
 {
-    [self trimToDateAsync:date completion:block];
+    [self trimToDateAsync:date completion:^(id<PINCaching> memoryCache) {
+        if (block) {
+            block((PINMemoryCache *)memoryCache);
+        }
+    }];
 }
 
 - (void)trimToCost:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block
 {
-    [self trimToCostAsync:cost completion:block];
+    [self trimToCostAsync:cost completion:^(id<PINCaching> memoryCache) {
+        if (block) {
+            block((PINMemoryCache *)memoryCache);
+        }
+    }];
 }
 
 - (void)trimToCostByDate:(NSUInteger)cost block:(nullable PINMemoryCacheBlock)block
 {
-    [self trimToCostByDateAsync:cost completion:block];
+    [self trimToCostByDateAsync:cost completion:^(id<PINCaching> memoryCache) {
+        if (block) {
+            block((PINMemoryCache *)memoryCache);
+        }
+    }];
 }
 
 - (void)removeAllObjects:(nullable PINMemoryCacheBlock)block
 {
-    [self removeAllObjectsAsync:block];
+    [self removeAllObjectsAsync:^(id<PINCaching> memoryCache) {
+        if (block) {
+            block((PINMemoryCache *)memoryCache);
+        }
+    }];
 }
 
 - (void)enumerateObjectsWithBlock:(PINMemoryCacheObjectBlock)block completionBlock:(nullable PINMemoryCacheBlock)completionBlock
@@ -878,7 +910,11 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
             PINMemoryCache *memoryCache = (PINMemoryCache *)cache;
             block(memoryCache, key, object);
         }
-    } completionBlock:completionBlock];
+    } completionBlock:^(id<PINCaching> memoryCache) {
+        if (completionBlock) {
+            completionBlock((PINMemoryCache *)memoryCache);
+        }
+    }];
 }
 
 - (void)setTtlCache:(BOOL)ttlCache


### PR DESCRIPTION
This beta added a diagnostic for passing more specific types to `id`-typed values:

> Fixed type checking for block parameters using id with protocols. The compiler now emits an error for method calls with a block that uses parameters more specific than arguments with which it will be called. (57980961)