### PR TITLE
Fix PINCacheTests compiling in Xcode 12.0b4

### DIFF
--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -130,7 +130,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block PINImage *image = nil;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     
-    [self.cache setObjectAsync:[self image] forKey:key completion:^(PINCache *cache, NSString *key, id object) {
+    [self.cache setObjectAsync:[self image] forKey:key completion:^(id<PINCaching> cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -148,7 +148,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     PINImage *srcImage = [self image];
     NSUInteger cost = (NSUInteger)(srcImage.size.width * srcImage.size.height);
     
-    [self.cache setObjectAsync:srcImage forKey:key withCost:cost completion:^(PINCache *cache, NSString *key, id object) {
+    [self.cache setObjectAsync:srcImage forKey:key withCost:cost completion:^(id<PINCaching> cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -170,7 +170,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     [self.cache setObject:value1 forKey:key];
     [self.cache setObject:value2 forKey:key];
     
-    [self.cache objectForKeyAsync:key completion:^(PINCache *cache, NSString *key, id object) {
+    [self.cache objectForKeyAsync:key completion:^(id<PINCaching> cache, NSString *key, id object) {
         cachedValue = (NSString *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -233,7 +233,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     
     self.cache[key] = [self image];
     
-    [self.cache objectForKeyAsync:key completion:^(PINCache *cache, NSString *key, id object) {
+    [self.cache objectForKeyAsync:key completion:^(id<PINCaching> cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -252,7 +252,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     self.cache[key] = [self image];
 
-    [self.cache objectForKeyAsync:invalidKey completion:^(PINCache *cache, NSString *key, id object) {
+    [self.cache objectForKeyAsync:invalidKey completion:^(id<PINCaching> cache, NSString *key, id object) {
         image = (PINImage *)object;
         dispatch_semaphore_signal(semaphore);
     }];
@@ -279,7 +279,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
         didRemoveObjectBlockCalled = YES;
     };
 
-    [self.cache removeObjectForKeyAsync:key completion:^(PINCache *cache, NSString *key, id object) {
+    [self.cache removeObjectForKeyAsync:key completion:^(id<PINCaching> cache, NSString *key, id object) {
         dispatch_semaphore_signal(semaphore);
     }];
     
@@ -311,7 +311,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
         didRemoveAllObjectsBlockCalled = YES;
     };
 
-    [self.cache removeAllObjectsAsync:^(PINCache *cache) {
+    [self.cache removeAllObjectsAsync:^(id<PINCaching> cache) {
         dispatch_semaphore_signal(semaphore);
     }];
     
@@ -505,9 +505,9 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
         dispatch_group_enter(group);
-        [self.cache setObjectAsync:obj forKey:key completion:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+        [self.cache setObjectAsync:obj forKey:key completion:^(id<PINCaching> _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
             dispatch_async(queue, ^{
-                [self.cache objectForKeyAsync:key completion:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+                [self.cache objectForKeyAsync:key completion:^(id<PINCaching> _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
                     NSString *obj = [[NSString alloc] initWithFormat:@"obj %lu", (unsigned long)i];
                     XCTAssertTrue([object isEqualToString:obj] == YES, @"object returned was not object set");
                     @synchronized (self) {
@@ -535,7 +535,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     __block BOOL blockDidExecute = NO;
 
-    self.cache.memoryCache.didReceiveMemoryWarningBlock = ^(PINMemoryCache *cache) {
+    self.cache.memoryCache.didReceiveMemoryWarningBlock = ^(id<PINCaching> cache) {
         blockDidExecute = YES;
         dispatch_semaphore_signal(semaphore);
     };
@@ -554,7 +554,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     __block BOOL blockDidExecute = NO;
 
-    self.cache.memoryCache.didEnterBackgroundBlock = ^(PINMemoryCache *cache) {
+    self.cache.memoryCache.didEnterBackgroundBlock = ^(id<PINCaching> cache) {
         blockDidExecute = YES;
         dispatch_semaphore_signal(semaphore);
     };
@@ -591,8 +591,8 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     __block id object = nil;
     
-    self.cache.memoryCache.didReceiveMemoryWarningBlock = ^(PINMemoryCache *cache) {
-        object = cache[@"object"];
+    self.cache.memoryCache.didReceiveMemoryWarningBlock = ^(id<PINCaching> cache) {
+        object = [cache objectForKey:@"object"];
         dispatch_semaphore_signal(semaphore);
     };
 
@@ -620,12 +620,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
 
     __block NSUInteger enumCount = 0;
 
-    self.cache.memoryCache.didReceiveMemoryWarningBlock = ^(PINMemoryCache *cache) {
-        [cache enumerateObjectsWithBlockAsync:^(PINMemoryCache *cache, NSString *key, id object, BOOL *stop) {
+    self.cache.memoryCache.didReceiveMemoryWarningBlock = ^(id<PINCaching> cache) {
+        PINMemoryCache *memoryCache = (PINMemoryCache *)cache;
+        [memoryCache enumerateObjectsWithBlockAsync:^(id<PINCaching> cache, NSString *key, id object, BOOL *stop) {
             @synchronized (self) {
                 enumCount++;
             }
-        } completionBlock:^(PINMemoryCache *cache) {
+        } completionBlock:^(id<PINCaching> cache) {
             dispatch_semaphore_signal(semaphore);
         }];
     };
@@ -665,7 +666,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
         @synchronized (self) {
             enumCount++;
         }
-    } completionBlock:^(PINDiskCache *cache) {
+    } completionBlock:^(id<PINCaching> cache) {
         dispatch_semaphore_signal(semaphore);
     }];
 
@@ -722,25 +723,25 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block id diskObj2 = nil;
     
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKeyAsync:key1 completion:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key1 completion:^(id<PINCaching> cache, NSString *key, id object) {
         memObj1 = object;
         dispatch_group_leave(group);
     }];
     
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKeyAsync:key2 completion:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key2 completion:^(id<PINCaching> cache, NSString *key, id object) {
         memObj2 = object;
         dispatch_group_leave(group);
     }];
     
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKeyAsync:key1 completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key1 completion:^(id<PINCaching> cache, NSString *key, id<NSCoding> object) {
         diskObj1 = object;
         dispatch_group_leave(group);
     }];
     
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKeyAsync:key2 completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key2 completion:^(id<PINCaching> cache, NSString *key, id<NSCoding> object) {
         diskObj2 = object;
         dispatch_group_leave(group);
     }];
@@ -765,19 +766,19 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     sleep(1);
     
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKeyAsync:key1 completion:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key1 completion:^(id<PINCaching> cache, NSString *key, id object) {
         memObj1 = object;
         dispatch_group_leave(group);
     }];
     
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKeyAsync:key2 completion:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key2 completion:^(id<PINCaching> cache, NSString *key, id object) {
         memObj2 = object;
         dispatch_group_leave(group);
     }];
     
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKeyAsync:key1 completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key1 completion:^(id<PINCaching> cache, NSString *key, id<NSCoding> object) {
         diskObj1 = object;
         dispatch_group_leave(group);
     }];
@@ -902,13 +903,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     __block id diskObj = nil;
 
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKeyAsync:key completion:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key completion:^(id<PINCaching> cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
 
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKeyAsync:key completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key completion:^(id<PINCaching> cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -926,13 +927,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     diskObj = nil;
 
     dispatch_group_enter(group);
-    [self.cache.memoryCache objectForKeyAsync:key completion:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key completion:^(id<PINCaching> cache, NSString *key, id object) {
         memObj = object;
         dispatch_group_leave(group);
     }];
 
     dispatch_group_enter(group);
-    [self.cache.diskCache objectForKeyAsync:key completion:^(PINDiskCache *cache, NSString *key, id<NSCoding> object) {
+    [self.cache.diskCache objectForKeyAsync:key completion:^(id<PINCaching> cache, NSString *key, id<NSCoding> object) {
         diskObj = object;
         dispatch_group_leave(group);
     }];
@@ -979,7 +980,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", (unsigned long)expectedObjCount);
 
     objCount = 0;
-    [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache *cache, NSString *key, id _Nullable object, BOOL *stop) {
+    [self.cache.memoryCache enumerateObjectsWithBlock:^(id<PINCaching> cache, NSString *key, id _Nullable object, BOOL *stop) {
       objCount++;
     }];
 
@@ -1005,7 +1006,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     XCTAssertEqual(objCount, expectedObjCount, @"Expected %lu objects in the cache", (unsigned long)expectedObjCount);
 
     objCount = 0;
-    [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object, BOOL *stop) {
+    [self.cache.memoryCache enumerateObjectsWithBlock:^(id<PINCaching> _Nonnull cache, NSString * _Nonnull key, id  _Nullable object, BOOL *stop) {
       objCount++;
     }];
 
@@ -1089,13 +1090,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Neither object should be expired at this point and should exist in both caches
 
     XCTestExpectation *memObjectForKey1Expectation = [self expectationWithDescription:@"memoryCache objectForKeyAsync - #1"];
-    [self.cache.memoryCache objectForKeyAsync:key1 completion:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key1 completion:^(id<PINCaching> cache, NSString *key, id object) {
         XCTAssertNotNil(object, @"should still be in memory cache");
         [memObjectForKey1Expectation fulfill];
     }];
 
     XCTestExpectation *memObjectForKey2Expectation = [self expectationWithDescription:@"memoryCache objectForKeyAsync - #2"];
-    [self.cache.memoryCache objectForKeyAsync:key2 completion:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key2 completion:^(id<PINCaching> cache, NSString *key, id object) {
         XCTAssertNotNil(object, @"should still be in memory cache");
         [memObjectForKey2Expectation fulfill];
     }];
@@ -1120,13 +1121,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // The first object has been expired for 30 seconds and should not exist in the cache anymore.
 
     memObjectForKey1Expectation = [self expectationWithDescription:@"memoryCache objectForKeyAsync - #1"];
-    [self.cache.memoryCache objectForKeyAsync:key1 completion:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key1 completion:^(id<PINCaching> cache, NSString *key, id object) {
         XCTAssertNil(object, @"should not be in memory cache");
         [memObjectForKey1Expectation fulfill];
     }];
 
     memObjectForKey2Expectation = [self expectationWithDescription:@"memoryCache objectForKeyAsync - #2"];
-    [self.cache.memoryCache objectForKeyAsync:key2 completion:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key2 completion:^(id<PINCaching> cache, NSString *key, id object) {
         XCTAssertNotNil(object, @"should not be in memory cache");
         [memObjectForKey2Expectation fulfill];
     }];
@@ -1162,7 +1163,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // Neither object should be expired at this point and should exist in both caches
 
     __block NSUInteger objCount = 0;
-    [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache *cache, NSString *key, id _Nullable object, BOOL *stop) {
+    [self.cache.memoryCache enumerateObjectsWithBlock:^(id<PINCaching> cache, NSString *key, id _Nullable object, BOOL *stop) {
         objCount++;
     }];
     XCTAssertEqual(objCount, 2, @"Expected 2 objects, got %tu.", objCount);
@@ -1179,7 +1180,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     // The first object has been expired for 30 seconds and should not exist in the cache anymore.
 
     objCount = 0;
-    [self.cache.memoryCache enumerateObjectsWithBlock:^(PINMemoryCache *cache, NSString *key, id _Nullable object, BOOL *stop) {
+    [self.cache.memoryCache enumerateObjectsWithBlock:^(id<PINCaching> cache, NSString *key, id _Nullable object, BOOL *stop) {
         objCount++;
     }];
     XCTAssertEqual(objCount, 1, @"Expected 1 object, got %tu.", objCount);
@@ -1215,13 +1216,13 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     [NSDate stopMockingDate];
 
     XCTestExpectation *memObjectForKey1Expectation = [self expectationWithDescription:@"memoryCache objectForKeyAsync - #1"];
-    [self.cache.memoryCache objectForKeyAsync:key1 completion:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key1 completion:^(id<PINCaching> cache, NSString *key, id object) {
         XCTAssertNil(object, @"should not be in memory cache");
         [memObjectForKey1Expectation fulfill];
     }];
 
     XCTestExpectation *memObjectForKey2Expectation = [self expectationWithDescription:@"memoryCache objectForKeyAsync - #2"];
-    [self.cache.memoryCache objectForKeyAsync:key2 completion:^(PINMemoryCache *cache, NSString *key, id object) {
+    [self.cache.memoryCache objectForKeyAsync:key2 completion:^(id<PINCaching> cache, NSString *key, id object) {
         XCTAssertNotNil(object, @"should not be in memory cache");
         [memObjectForKey2Expectation fulfill];
     }];
@@ -1347,7 +1348,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     }
     
     dispatch_group_enter(group);
-    [self.cache.diskCache removeAllObjectsAsync:^(PINDiskCache * _Nonnull cache) {
+    [self.cache.diskCache removeAllObjectsAsync:^(id<PINCaching>  _Nonnull cache) {
         // Temporary directory should be bigger now since the trash directory is still inside it
         NSError *error = nil;
         unsigned long long tempDirSize = [[fileManager attributesOfItemAtPath:trashPath error:&error] fileSize];


### PR DESCRIPTION
Fixed type checking for block parameters in tests using id with
protocols. Same as commit 10b3c3c6 did.