### PR TITLE
Added SPM support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,10 +52,10 @@ jobs:
   SPM-Build:
     runs-on: macos-latest
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12_beta.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Verify that PINCache can be build by SPM
-        run: xcrun swift build
+        run: make spm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,15 +37,25 @@ jobs:
     name: CocoaPods
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Lint
         run: pod lib lint
   carthage:
     name: Carthage
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Update
         run: carthage update --no-use-binaries --no-build
       - name: Build
         run: carthage build --no-skip-current
+  SPM-Build:
+    runs-on: macos-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12_beta.app/Contents/Developer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Verify that PINCache can be build by SPM
+        run: xcrun swift build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,12 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_12_beta.app/Contents/Developer
     steps:
+      - name: "Add GitHub to the SSH known hosts file"
+        run: |
+          for ip in $(dig @8.8.8.8 github.com +short); do \
+            ssh-keyscan github.com,$ip; \
+            ssh-keyscan $ip; \
+          done 2>/dev/null >> ~/.ssh/known_hosts
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,12 +54,6 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_12_beta.app/Contents/Developer
     steps:
-      - name: "Add GitHub to the SSH known hosts file"
-        run: |
-          for ip in $(dig @8.8.8.8 github.com +short); do \
-            ssh-keyscan github.com,$ip; \
-            ssh-keyscan $ip; \
-          done 2>/dev/null >> ~/.ssh/known_hosts
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ xcuserdata
 /.buckd
 
 Carthage/Build
+
+# SPM
+.swiftpm/
+.build/
+Package.resolved

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PLATFORM="platform=iOS Simulator,name=iPhone 8"
 SDK="iphonesimulator"
 SHELL=/bin/bash -o pipefail
 
-.PHONY: all lint test carthage analyze
+.PHONY: all lint test carthage analyze spm
 
 lint:
 	pod lib lint
@@ -25,4 +25,10 @@ carthage:
 	carthage update --no-use-binaries --no-build
 	carthage build --no-skip-current
 
-all: carthage lint test analyze
+spm:
+# For now just check whether we can assemble it
+# TODO: replace it with "swift test --enable-test-discovery --sanitize=thread" when swiftPM resource-related bug would be fixed.
+# https://bugs.swift.org/browse/SR-13560
+	swift build
+
+all: carthage lint test analyze spm

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,47 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "PINCache",
+    platforms: [
+        .macOS(.v10_10),
+        .iOS(.v9),
+        .watchOS(.v2),
+        .tvOS(.v9)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "PINCache",
+            targets: ["PINCache"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "git@github.com:pinterest/PINOperation.git",  .branch("master")),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "PINCache",
+            dependencies: ["PINOperation"],
+            path: "Source",
+            exclude: ["Carthage", "docs",
+                      "build_docs.sh", "Cartfile",
+                      "Cartfile.resolved", "Makefile",
+                      "PINCache.podspec", "Info.plist"],
+            publicHeadersPath: "."),
+        .testTarget(
+            name: "PINCacheTests",
+            dependencies: ["PINCache"],
+            path: "Tests",
+            exclude: ["Info.plist"],
+            resources: [.process("Default-568h@2x.png")],
+            cSettings: [
+                .define("TEST_AS_SPM"),
+            ]),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/pinterest/PINOperation.git",  .branch("master")),
+        .package(url: "https://github.com/pinterest/PINOperation.git", from: "1.2.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "git@github.com:pinterest/PINOperation.git",  .branch("master")),
+        .package(url: "https://github.com/pinterest/PINOperation.git",  .branch("master")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -4,10 +4,10 @@
 
 #import <Foundation/Foundation.h>
 
-#import <PINCache/PINCacheMacros.h>
-#import <PINCache/PINCaching.h>
-#import <PINCache/PINDiskCache.h>
-#import <PINCache/PINMemoryCache.h>
+#import "PINCacheMacros.h"
+#import "PINCaching.h"
+#import "PINDiskCache.h"
+#import "PINMemoryCache.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -4,7 +4,7 @@
 
 #import "PINCache.h"
 
-#import <PINOperation/PINOperation.h>
+@import PINOperation;
 
 static NSString * const PINCachePrefix = @"com.pinterest.PINCache";
 static NSString * const PINCacheSharedName = @"PINCacheShared";

--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -4,9 +4,9 @@
 
 #import <Foundation/Foundation.h>
 
-#import <PINCache/PINCacheMacros.h>
-#import <PINCache/PINCaching.h>
-#import <PINCache/PINCacheObjectSubscripting.h>
+#import "PINCacheMacros.h"
+#import "PINCaching.h"
+#import "PINCacheObjectSubscripting.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -11,7 +11,7 @@
 #import <pthread.h>
 #import <sys/xattr.h>
 
-#import <PINOperation/PINOperation.h>
+@import PINOperation;
 
 #define PINDiskCacheError(error) if (error) { NSLog(@"%@ (%d) ERROR: %@", \
 [[NSString stringWithUTF8String:__FILE__] lastPathComponent], \

--- a/Source/PINMemoryCache.h
+++ b/Source/PINMemoryCache.h
@@ -4,9 +4,9 @@
 
 #import <Foundation/Foundation.h>
 
-#import <PINCache/PINCacheMacros.h>
-#import <PINCache/PINCaching.h>
-#import <PINCache/PINCacheObjectSubscripting.h>
+#import "PINCacheMacros.h"
+#import "PINCaching.h"
+#import "PINCacheObjectSubscripting.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -5,7 +5,7 @@
 #import "PINMemoryCache.h"
 
 #import <pthread.h>
-#import <PINOperation/PINOperation.h>
+@import PINOperation;
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
 #import <UIKit/UIKit.h>

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -2,11 +2,12 @@
 //  Modifications by Garrett Moon
 //  Copyright (c) 2015 Pinterest. All rights reserved.
 
+@import PINCache;
+@import PINOperation;
+
 #import "PINCacheTests.h"
 #import "NSDate+PINCacheTests.h"
 #import "PINDiskCache+PINCacheTests.h"
-#import <PINCache/PINCache.h>
-#import <PINOperation/PINOperation.h>
 
 
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
@@ -79,8 +80,14 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     static PINImage *image = nil;
     
     if (!image) {
+#ifdef TEST_AS_SPM
+        NSBundle *bun = [NSBundle bundleWithURL:[[NSBundle bundleForClass:self.class] URLForResource:@"PINCache_PINCacheTests" withExtension:@"bundle"]];
+#else
+        NSBundle *bun = [NSBundle bundleForClass:self.class];
+
+#endif
+        NSURL *imageURL = [bun URLForResource:@"Default-568h@2x" withExtension:@"png"];
         NSError *error = nil;
-        NSURL *imageURL = [[NSBundle bundleForClass:self.class] URLForResource:@"Default-568h@2x" withExtension:@"png"];
         NSData *imageData = [[NSData alloc] initWithContentsOfURL:imageURL
                                                           options:NSDataReadingUncached
                                                             error:&error];

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -81,7 +81,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     
     if (!image) {
 #ifdef TEST_AS_SPM
-        NSBundle *bun = [NSBundle bundleWithURL:[[NSBundle bundleForClass:self.class] URLForResource:@"PINCache_PINCacheTests" withExtension:@"bundle"]];
+        NSBundle *bun = SWIFTPM_MODULE_BUNDLE;
 #else
         NSBundle *bun = [NSBundle bundleForClass:self.class];
 

--- a/Tests/PINDiskCache+PINCacheTests.h
+++ b/Tests/PINDiskCache+PINCacheTests.h
@@ -1,4 +1,4 @@
-#import <PINCache/PINCache.h>
+#import "PINCache.h"
 
 @interface PINDiskCache (PINCacheTests)
 

--- a/Tests/PINDiskCache+PINCacheTests.m
+++ b/Tests/PINDiskCache+PINCacheTests.m
@@ -15,7 +15,7 @@
 - (void)setTtlCacheSync:(BOOL)ttlCache
 {
     [self lock];
-        self->_ttlCache = ttlCache;
+    [self setValue:@(ttlCache) forKey:@"_ttlCache"];
     [self unlock];
 }
 


### PR DESCRIPTION
Added SPM support starting from Swift 5.3 (since it supports resources). Some notes:

- SPM tests not passing when you run it from a command line (SPM(bug)? gets the wrong bundle path) but passing if you use Xcode in SPM edit mode(just open as a package instead of .xcodeproj).

- dependency strategy for `PINOperation` set as - branch `master`. I believe it should be set - from `PINOperation 1.2.0` but unfortunately, it was tagged as `1.2` and SPM can not resolve it. Can the maintainers re-tag/new it with proper sem-ver?