### PR TITLE
Fixed spm integration on regular Xcode project.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,7 @@ jobs:
     name: Carthage
     runs-on: macOS-latest
     env:
-      # Carthage is broken in Xcode 12 and above https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md
-      DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: carthage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,3 +54,21 @@ jobs:
         uses: actions/checkout@v2
       - name: Verify that PINCache can be build by SPM
         run: make spm
+  xcode-spm-integration:
+    name: Build iOS example project 
+    runs-on: macOS-latest
+    env: 
+      DEVELOPER_DIR: /Applications/Xcode_12.1.1.app/Contents/Developer
+      IOS_EXAMPLE_PROJECT: IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration.xcodeproj
+      EXAMPLE_SCHEME: PINCache-SPM-Integration
+    strategy:
+      matrix:
+        destination: ["name=iPhone 12 Pro"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check Xcode's spm integration
+        run: |
+          set -o pipefail
+          xcodebuild clean build -project "${{ env.IOS_EXAMPLE_PROJECT }}" -scheme "${{ env.EXAMPLE_SCHEME }}" -destination "${{ matrix.destination }}" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
   swift-package-manager:
     runs-on: macos-latest
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,18 +57,9 @@ jobs:
   xcode-spm-integration:
     name: Build iOS example project 
     runs-on: macOS-latest
-    env: 
-      DEVELOPER_DIR: /Applications/Xcode_12.1.1.app/Contents/Developer
-      IOS_EXAMPLE_PROJECT: IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration.xcodeproj
-      EXAMPLE_SCHEME: PINCache-SPM-Integration
-    strategy:
-      matrix:
-        destination: ["name=iPhone 12 Pro"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Check Xcode's spm integration
-        run: |
-          set -o pipefail
-          xcodebuild clean build -project "${{ env.IOS_EXAMPLE_PROJECT }}" -scheme "${{ env.EXAMPLE_SCHEME }}" -destination "${{ matrix.destination }}" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO
+        run: make example

--- a/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration.xcodeproj/project.pbxproj
+++ b/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration.xcodeproj/project.pbxproj
@@ -1,0 +1,355 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		E03DEAC225671BA900ACCAFC /* PINCache_SPM_IntegrationApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03DEAC125671BA900ACCAFC /* PINCache_SPM_IntegrationApp.swift */; };
+		E03DEAC425671BA900ACCAFC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03DEAC325671BA900ACCAFC /* ContentView.swift */; };
+		E03DEAC625671BAE00ACCAFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E03DEAC525671BAE00ACCAFC /* Assets.xcassets */; };
+		E03DEAC925671BAE00ACCAFC /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E03DEAC825671BAE00ACCAFC /* Preview Assets.xcassets */; };
+		E03DEB1B256BD0CB00ACCAFC /* PINCache in Frameworks */ = {isa = PBXBuildFile; productRef = E03DEB1A256BD0CB00ACCAFC /* PINCache */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		E03DEABE25671BA900ACCAFC /* PINCache-SPM-Integration.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "PINCache-SPM-Integration.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E03DEAC125671BA900ACCAFC /* PINCache_SPM_IntegrationApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PINCache_SPM_IntegrationApp.swift; sourceTree = "<group>"; };
+		E03DEAC325671BA900ACCAFC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		E03DEAC525671BAE00ACCAFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E03DEAC825671BAE00ACCAFC /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		E03DEACA25671BAE00ACCAFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E03DEB18256BD05A00ACCAFC /* PINCache */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PINCache; path = ../../..; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E03DEABB25671BA900ACCAFC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E03DEB1B256BD0CB00ACCAFC /* PINCache in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		E03DEAB525671BA900ACCAFC = {
+			isa = PBXGroup;
+			children = (
+				E03DEAC025671BA900ACCAFC /* PINCache-SPM-Integration */,
+				E03DEABF25671BA900ACCAFC /* Products */,
+				E03DEAD325671F1100ACCAFC /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		E03DEABF25671BA900ACCAFC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E03DEABE25671BA900ACCAFC /* PINCache-SPM-Integration.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E03DEAC025671BA900ACCAFC /* PINCache-SPM-Integration */ = {
+			isa = PBXGroup;
+			children = (
+				E03DEB18256BD05A00ACCAFC /* PINCache */,
+				E03DEAC125671BA900ACCAFC /* PINCache_SPM_IntegrationApp.swift */,
+				E03DEAC325671BA900ACCAFC /* ContentView.swift */,
+				E03DEAC525671BAE00ACCAFC /* Assets.xcassets */,
+				E03DEACA25671BAE00ACCAFC /* Info.plist */,
+				E03DEAC725671BAE00ACCAFC /* Preview Content */,
+			);
+			path = "PINCache-SPM-Integration";
+			sourceTree = "<group>";
+		};
+		E03DEAC725671BAE00ACCAFC /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				E03DEAC825671BAE00ACCAFC /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		E03DEAD325671F1100ACCAFC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E03DEABD25671BA900ACCAFC /* PINCache-SPM-Integration */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E03DEACD25671BAE00ACCAFC /* Build configuration list for PBXNativeTarget "PINCache-SPM-Integration" */;
+			buildPhases = (
+				E03DEABA25671BA900ACCAFC /* Sources */,
+				E03DEABB25671BA900ACCAFC /* Frameworks */,
+				E03DEABC25671BA900ACCAFC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PINCache-SPM-Integration";
+			packageProductDependencies = (
+				E03DEB1A256BD0CB00ACCAFC /* PINCache */,
+			);
+			productName = "PINCache-SPM-Integration";
+			productReference = E03DEABE25671BA900ACCAFC /* PINCache-SPM-Integration.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E03DEAB625671BA900ACCAFC /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1210;
+				LastUpgradeCheck = 1210;
+				TargetAttributes = {
+					E03DEABD25671BA900ACCAFC = {
+						CreatedOnToolsVersion = 12.1;
+					};
+				};
+			};
+			buildConfigurationList = E03DEAB925671BA900ACCAFC /* Build configuration list for PBXProject "PINCache-SPM-Integration" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E03DEAB525671BA900ACCAFC;
+			packageReferences = (
+			);
+			productRefGroup = E03DEABF25671BA900ACCAFC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E03DEABD25671BA900ACCAFC /* PINCache-SPM-Integration */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E03DEABC25671BA900ACCAFC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E03DEAC925671BAE00ACCAFC /* Preview Assets.xcassets in Resources */,
+				E03DEAC625671BAE00ACCAFC /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E03DEABA25671BA900ACCAFC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E03DEAC425671BA900ACCAFC /* ContentView.swift in Sources */,
+				E03DEAC225671BA900ACCAFC /* PINCache_SPM_IntegrationApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		E03DEACB25671BAE00ACCAFC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		E03DEACC25671BAE00ACCAFC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		E03DEACE25671BAE00ACCAFC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"PINCache-SPM-Integration/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "PINCache-SPM-Integration/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "pintrest.PINCache-SPM-Integration";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E03DEACF25671BAE00ACCAFC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"PINCache-SPM-Integration/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "PINCache-SPM-Integration/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "pintrest.PINCache-SPM-Integration";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E03DEAB925671BA900ACCAFC /* Build configuration list for PBXProject "PINCache-SPM-Integration" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E03DEACB25671BAE00ACCAFC /* Debug */,
+				E03DEACC25671BAE00ACCAFC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E03DEACD25671BAE00ACCAFC /* Build configuration list for PBXNativeTarget "PINCache-SPM-Integration" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E03DEACE25671BAE00ACCAFC /* Debug */,
+				E03DEACF25671BAE00ACCAFC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		E03DEB1A256BD0CB00ACCAFC /* PINCache */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PINCache;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = E03DEAB625671BA900ACCAFC /* Project object */;
+}

--- a/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration.xcodeproj/xcshareddata/xcschemes/PINCache-SPM-Integration.xcscheme
+++ b/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration.xcodeproj/xcshareddata/xcschemes/PINCache-SPM-Integration.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1210"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E03DEABD25671BA900ACCAFC"
+               BuildableName = "PINCache-SPM-Integration.app"
+               BlueprintName = "PINCache-SPM-Integration"
+               ReferencedContainer = "container:PINCache-SPM-Integration.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E03DEABD25671BA900ACCAFC"
+            BuildableName = "PINCache-SPM-Integration.app"
+            BlueprintName = "PINCache-SPM-Integration"
+            ReferencedContainer = "container:PINCache-SPM-Integration.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E03DEABD25671BA900ACCAFC"
+            BuildableName = "PINCache-SPM-Integration.app"
+            BlueprintName = "PINCache-SPM-Integration"
+            ReferencedContainer = "container:PINCache-SPM-Integration.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/Assets.xcassets/Contents.json
+++ b/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/ContentView.swift
+++ b/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/ContentView.swift
@@ -1,0 +1,35 @@
+//
+//  ContentView.swift
+//  PINCache-SPM-Integration
+//
+//  Created by Petro Rovenskyy on 19.11.2020.
+//
+
+import SwiftUI
+import PINCache
+
+struct ContentView: View {
+    let cacheKey: String
+    @State
+    private var cachedValue: String = "loading..."
+    var body: some View {
+        Text(cachedValue)
+            .onAppear(perform: loadValue)
+            .padding()
+    }
+    private func loadValue() {
+        PINCache.shared.object(forKeyAsync: self.cacheKey, completion: { (_, _, object) in
+            if let object: String = object as? String {
+                self.cachedValue = object
+                return
+            }
+            self.cachedValue = "Failed to load value from cache"
+        })
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView(cacheKey: AppDelegate.cacheKey)
+    }
+}

--- a/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/Info.plist
+++ b/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/PINCache_SPM_IntegrationApp.swift
+++ b/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/PINCache_SPM_IntegrationApp.swift
@@ -1,0 +1,29 @@
+//
+//  PINCache_SPM_IntegrationApp.swift
+//  PINCache-SPM-Integration
+//
+//  Created by Petro Rovenskyy on 19.11.2020.
+//
+
+import SwiftUI
+import PINCache
+
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    static let cacheKey: String = "pinCache"
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        PINCache.shared.setObject("Hello! I'm cached string",
+                                  forKey: Self.cacheKey)
+        return true
+    }
+}
+
+@main
+struct PINCache_SPM_IntegrationApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+    var body: some Scene {
+        WindowGroup {
+            ContentView(cacheKey: AppDelegate.cacheKey)
+        }
+    }
+}

--- a/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -26,18 +26,10 @@ test:
 	CODE_SIGNING_REQUIRED=NO | xcpretty
 
 carthage:
-	if [ ${XCODE_MAJOR_VERSION} -gt 11 ] ; then \
-		echo "Carthage no longer works in Xcode 12 https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md"; \
-		exit 1; \
-	fi
 	# To workaround https://github.com/Carthage/Carthage/issues/1974 on CI
-	# just rename example's project file before running carthage.
-	mv ${IOS_EXAMPLE_PROJECT} ${EXAMPLE_PROJECT_CARTHAGE_WORKAROUND}
-	# start crthage
-	carthage update --no-use-binaries --no-build
-	carthage build --no-skip-current
-	# revert back
-	mv ${EXAMPLE_PROJECT_CARTHAGE_WORKAROUND} ${IOS_EXAMPLE_PROJECT}
+	##### Apply workaround https://github.com/Carthage/Carthage/issues/3019#issuecomment-734415287
+	./carthage.sh update --no-use-binaries --no-build; \
+	./carthage.sh build --no-skip-current;
 
 spm:
 # For now just check whether we can assemble it

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ SDK="iphonesimulator"
 SHELL=/bin/bash -o pipefail
 XCODE_MAJOR_VERSION=$(shell xcodebuild -version | HEAD -n 1 | sed -E 's/Xcode ([0-9]+).*/\1/')
 IOS_EXAMPLE_PROJECT="IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration.xcodeproj"
-EXAMPLE_PROJECT_CARTHAGE_WORKAROUND="IntegrationTests/PINCache-SPM-Integration/PINCache-SPM-Integration.carthageWorkaround"
 EXAMPLE_SCHEME="PINCache-SPM-Integration"
 
 .PHONY: all cocoapods test carthage analyze spm example

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -4,8 +4,8 @@
 
 #import "PINCache.h"
 
-#if SWIFT_PACKAGE
-@import PINOperation;
+#if !__has_include (<PINOperation/PINOperation.h>)
+#import "PINOperation.h"
 #else
 #import <PINOperation/PINOperation.h>
 #endif

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -11,8 +11,8 @@
 #import <pthread.h>
 #import <sys/xattr.h>
 
-#if SWIFT_PACKAGE
-@import PINOperation;
+#if !__has_include (<PINOperation/PINOperation.h>)
+#import "PINOperation.h"
 #else
 #import <PINOperation/PINOperation.h>
 #endif

--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -6,8 +6,8 @@
 
 #import <pthread.h>
 
-#if SWIFT_PACKAGE
-@import PINOperation;
+#if !__has_include (<PINOperation/PINOperation.h>)
+#import "PINOperation.h"
 #else
 #import <PINOperation/PINOperation.h>
 #endif

--- a/Tests/PINCacheTests.m
+++ b/Tests/PINCacheTests.m
@@ -2,11 +2,16 @@
 //  Modifications by Garrett Moon
 //  Copyright (c) 2015 Pinterest. All rights reserved.
 
-#if SWIFT_PACKAGE
-@import PINCache;
-@import PINOperation;
+
+#if !__has_include (<PINCache/PINCache.h>)
+#import "PINCache.h"
 #else
 #import <PINCache/PINCache.h>
+#endif
+
+#if !__has_include (<PINOperation/PINOperation.h>)
+#import "PINOperation.h"
+#else
 #import <PINOperation/PINOperation.h>
 #endif
 

--- a/carthage.sh
+++ b/carthage.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# ISSUE: https://github.com/Carthage/Carthage/issues/3019
+# CREDITS: https://github.com/Carthage/Carthage/issues/3019#issuecomment-734415287
+# carthage.sh
+# Usage example: ./carthage.sh build --platform iOS
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+for simulator in iphonesimulator appletvsimulator; do
+    echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_${simulator}__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+done
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(PLATFORM_NAME)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+cat $XCODE_XCCONFIG_FILE
+carthage "$@"


### PR DESCRIPTION
 - without this change project itself can be built as spm package, but failed to do so when you integrate it as a dependency via Xcode.