### PR TITLE
Remove invalid excludes from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,10 +29,7 @@ let package = Package(
             name: "PINCache",
             dependencies: ["PINOperation"],
             path: "Source",
-            exclude: ["Carthage", "docs",
-                      "build_docs.sh", "Cartfile",
-                      "Cartfile.resolved", "Makefile",
-                      "PINCache.podspec", "Info.plist"],
+            exclude: ["Info.plist"],
             publicHeadersPath: "."),
         .testTarget(
             name: "PINCacheTests",


### PR DESCRIPTION
Excludes are valid within the `Source` directory only. As the previously specified exclude paths are one level higher in the root directory, they are not found by Xcode, which emits annoying warnings which are fixed by this commit.