### PR TITLE
[Fix] Disk cache always trims cache to default size on creation

### DIFF
--- a/Source/PINDiskCache.h
+++ b/Source/PINDiskCache.h
@@ -334,7 +334,36 @@ PIN_SUBCLASSING_RESTRICTED
                   keyEncoder:(nullable PINDiskCacheKeyEncoderBlock)keyEncoder
                   keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyDecoder
               operationQueue:(nonnull PINOperationQueue *)operationQueue
-                    ttlCache:(BOOL)ttlCache NS_DESIGNATED_INITIALIZER;
+                    ttlCache:(BOOL)ttlCache;
+
+/**
+ The designated initializer allowing you to override default NSKeyedArchiver/NSKeyedUnarchiver serialization.
+ 
+ @see name
+ @param name The name of the cache.
+ @param prefix The prefix for the cache name. Defaults to com.pinterest.PINDiskCache
+ @param rootPath The path of the cache.
+ @param serializer   A block used to serialize object. If nil provided, default NSKeyedArchiver serialized will be used.
+ @param deserializer A block used to deserialize object. If nil provided, default NSKeyedUnarchiver serialized will be used.
+ @param keyEncoder A block used to encode key(filename). If nil provided, default url encoder will be used
+ @param keyDecoder A block used to decode key(filename). If nil provided, default url decoder will be used
+ @param operationQueue A PINOperationQueue to run asynchronous operations
+ @param ttlCache Whether or not the cache should behave as a TTL cache.
+ @param byteLimit The maximum number of bytes allowed on disk. Defaults to 50MB.
+ @param ageLimit The maximum number of seconds an object is allowed to exist in the cache. Defaults to 30 days.
+ @result A new cache with the specified name.
+ */
+- (instancetype)initWithName:(nonnull NSString *)name
+                      prefix:(nonnull NSString *)prefix
+                    rootPath:(nonnull NSString *)rootPath
+                  serializer:(nullable PINDiskCacheSerializerBlock)serializer
+                deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
+                  keyEncoder:(nullable PINDiskCacheKeyEncoderBlock)keyEncoder
+                  keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyDecoder
+              operationQueue:(nonnull PINOperationQueue *)operationQueue
+                    ttlCache:(BOOL)ttlCache
+                   byteLimit:(NSUInteger)byteLimit
+                    ageLimit:(NSTimeInterval)ageLimit NS_DESIGNATED_INITIALIZER;
 
 #pragma mark - Asynchronous Methods
 /// @name Asynchronous Methods

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -189,6 +189,30 @@ static NSURL *_sharedTrashURL;
               operationQueue:(PINOperationQueue *)operationQueue
                     ttlCache:(BOOL)ttlCache
 {
+    return [self initWithName:name prefix:prefix
+                     rootPath:rootPath
+                   serializer:serializer
+                 deserializer:deserializer
+                   keyEncoder:keyEncoder
+                   keyDecoder:keyDecoder
+               operationQueue:operationQueue
+                     ttlCache:NO
+                    byteLimit:50 * 1024 * 1024 // 50 MB by default
+                     ageLimit:60 * 60 * 24 * 30]; // 30 days by default
+}
+
+- (instancetype)initWithName:(NSString *)name
+                      prefix:(NSString *)prefix
+                    rootPath:(NSString *)rootPath
+                  serializer:(PINDiskCacheSerializerBlock)serializer
+                deserializer:(PINDiskCacheDeserializerBlock)deserializer
+                  keyEncoder:(PINDiskCacheKeyEncoderBlock)keyEncoder
+                  keyDecoder:(PINDiskCacheKeyDecoderBlock)keyDecoder
+              operationQueue:(PINOperationQueue *)operationQueue
+                    ttlCache:(BOOL)ttlCache
+                   byteLimit:(NSUInteger)byteLimit
+                    ageLimit:(NSTimeInterval)ageLimit
+{
     if (!name) {
         return nil;
     }
@@ -215,11 +239,8 @@ static NSURL *_sharedTrashURL;
         _didRemoveAllObjectsBlock = nil;
         
         _byteCount = 0;
-        
-        // 50 MB by default
-        _byteLimit = 50 * 1024 * 1024;
-        // 30 days by default
-        _ageLimit = 60 * 60 * 24 * 30;
+        _byteLimit = byteLimit;
+        _ageLimit = ageLimit;
         
 #if TARGET_OS_IPHONE
         _writingProtectionOptionSet = NO;

--- a/Source/PINDiskCache.m
+++ b/Source/PINDiskCache.m
@@ -196,7 +196,7 @@ static NSURL *_sharedTrashURL;
                    keyEncoder:keyEncoder
                    keyDecoder:keyDecoder
                operationQueue:operationQueue
-                     ttlCache:NO
+                     ttlCache:ttlCache
                     byteLimit:50 * 1024 * 1024 // 50 MB by default
                      ageLimit:60 * 60 * 24 * 30]; // 30 days by default
 }


### PR DESCRIPTION
There's a bug currently where `PINDiskCache` will always trim cache size to 50MB when creating since it defaults to 50MB in the init, and immediately trims cache in `[self initializeDiskProperties];`. This is obviously not ideal since if we specify a cache size >50MB then we will constantly be having to refetch assets on each app open since it will trim to 50MB each time.

Proposed fix:
- Add two new fields to designated init to allow passing in custom `byteLimit` and `ageLimit`
- Keep convenience init to maintain API stability that defaults to 50MB/30 days