### PR TITLE
Disable asserts in release builds when using Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,9 @@ let package = Package(
             path: "Source",
             exclude: ["Info.plist"],
             publicHeadersPath: "."),
+            cSettings: [
+                .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release)),
+            ]),
         .testTarget(
             name: "PINCacheTests",
             dependencies: ["PINCache"],
@@ -39,6 +42,7 @@ let package = Package(
             resources: [.process("Default-568h@2x.png")],
             cSettings: [
                 .define("TEST_AS_SPM"),
+                .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release)),
             ]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
             dependencies: ["PINOperation"],
             path: "Source",
             exclude: ["Info.plist"],
-            publicHeadersPath: "."),
+            publicHeadersPath: ".",
             cSettings: [
                 .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release)),
             ]),


### PR DESCRIPTION
When using Swift Package Manager to integrate `PINCache` into an app, Xcode does not automatically set `NS_BLOCK_ASSERTIONS` to `1` when building the package in release. This means that any `NSAsserts` that are hit in release cause crashes. This appears to only be an issue with [ObjC packages](https://forums.swift.org/t/assertions-in-swift-packages/42692). 

The change I've made is to `Package.swift` to set `NS_BLOCK_ASSERTIONS` to `1` when building in release.

(Note: I didn't actually hit an assert in this PINCache, but the possibility is there)