### PR TITLE
Only sort accessDates if totalCost exceeds costLimit

### DIFF
--- a/Source/PINMemoryCache.m
+++ b/Source/PINMemoryCache.m
@@ -264,15 +264,16 @@ static NSString * const PINMemoryCacheSharedName = @"PINMemoryCacheSharedName";
         [self removeExpiredObjects];
     }
 
-    NSUInteger totalCost = 0;
-    
     [self lock];
-        totalCost = _totalCost;
-        NSArray *keysSortedByAccessDate = [_accessDates keysSortedByValueUsingSelector:@selector(compare:)];
+        NSUInteger totalCost = _totalCost;
     [self unlock];
     
     if (totalCost <= limit)
         return;
+    
+    [self lock];
+        NSArray *keysSortedByAccessDate = [_accessDates keysSortedByValueUsingSelector:@selector(compare:)];
+    [self unlock];
 
     for (NSString *key in keysSortedByAccessDate) { // oldest objects first
         [self removeObjectAndExecuteBlocksForKey:key];


### PR DESCRIPTION
As the number of cached objects increases, sorting the accessDates becomes expensive. The access dates should only be sorted if the totalCost is greater than the limit. 