### PR TITLE
Stop specifying Xcode 12, no longer necessary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,8 +46,6 @@ jobs:
         run: make carthage
   swift-package-manager:
     runs-on: macos-latest
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,8 +38,6 @@ jobs:
   carthage:
     name: Carthage
     runs-on: macOS-latest
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: carthage

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,8 @@ test:
 	CODE_SIGNING_REQUIRED=NO | xcpretty
 
 carthage:
-	# To workaround https://github.com/Carthage/Carthage/issues/1974 on CI
-	##### Apply workaround https://github.com/Carthage/Carthage/issues/3019#issuecomment-734415287
-	./carthage.sh update --no-use-binaries --no-build; \
-	./carthage.sh build --no-skip-current;
+	./carthage.sh update --no-use-binaries --no-build;
+	./carthage.sh build --no-skip-current --use-xcframeworks;
 
 spm:
 # For now just check whether we can assemble it


### PR DESCRIPTION
This should hopefully fix up the CI