### PR TITLE
Add PrivacyInfo.xcprivacy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
             dependencies: ["PINOperation"],
             path: "Source",
             exclude: ["Info.plist"],
+            resources: [.copy("../PrivacyInfo.xcprivacy")],
             publicHeadersPath: ".",
             cSettings: [
                 .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release)),

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>0A2A.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
Addresses #324.

See [Describing use of required reason API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api) for more information.

| Required Reason API Used          | Used in File                   |
|-----------------------------------|--------------------------------|
| NSFileModificationDate            | PINCache/Source/PINDiskCache.m |
| NSFileModificationDate            | PINCache/Tests/PINCacheTests.m |
| NSURLContentModificationDateKey   | PINCache/Source/PINDiskCache.m |
| NSURLCreationDateKey              | PINCache/Source/PINDiskCache.m |