### PR TITLE
Add PrivacyInfo.xcprivacy to podspec

### DIFF
--- a/PINCache.podspec
+++ b/PINCache.podspec
@@ -5,6 +5,7 @@ Pod::Spec.new do |s|
   s.summary       = 'Fast, thread safe, parallel object cache for iOS and OS X.'
   s.authors       = { 'Garrett Moon' => 'garrett@pinterest.com', 'Justin Ouellette' => 'jstn@tumblr.com' }
   s.source        = { :git => 'https://github.com/pinterest/PINCache.git', :tag => "#{s.version}" }
+  s.resource_bundles = {'PINCache' => ['PrivacyInfo.xcprivacy']}
   s.license       = { :type => 'Apache 2.0', :file => 'LICENSE.txt' }
   s.requires_arc  = true
   s.frameworks    = 'Foundation'


### PR DESCRIPTION
Related to https://github.com/pinterest/PINCache/issues/324.

Added `PrivacyInfo.xcprivacy` to `PINCache.podspec` so it's included in Resources when installing via Cocoapods.